### PR TITLE
Address review findings cleanup

### DIFF
--- a/clients/desktop/store_test.go
+++ b/clients/desktop/store_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -19,6 +20,42 @@ func TestStoreLoadMissingConfigUsesDefaults(t *testing.T) {
 	cfg := store.getSettings()
 	if cfg.ServerURL != "http://127.0.0.1:8080" {
 		t.Fatalf("ServerURL = %q, want default", cfg.ServerURL)
+	}
+}
+
+func TestWailsRecordDTOsDoNotExposeTimeTime(t *testing.T) {
+	t.Parallel()
+
+	timeType := reflect.TypeOf(time.Time{})
+	for _, typ := range []reflect.Type{
+		reflect.TypeOf(LocalRecord{}),
+		reflect.TypeOf(RecordPage{}),
+		reflect.TypeOf(SubmitResult{}),
+	} {
+		assertNoTimeTimeFields(t, typ, timeType)
+	}
+}
+
+func assertNoTimeTimeFields(t *testing.T, typ, timeType reflect.Type) {
+	t.Helper()
+	if typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	if typ == timeType {
+		t.Fatalf("%s exposes time.Time to Wails bindings", typ)
+	}
+	if typ.Kind() != reflect.Struct {
+		return
+	}
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		ft := field.Type
+		for ft.Kind() == reflect.Pointer || ft.Kind() == reflect.Slice {
+			ft = ft.Elem()
+		}
+		if ft == timeType {
+			t.Fatalf("%s.%s exposes time.Time to Wails bindings", typ, field.Name)
+		}
 	}
 }
 

--- a/cmd/trustdb/serve_cmd.go
+++ b/cmd/trustdb/serve_cmd.go
@@ -887,9 +887,8 @@ func replayWALAccepted(ctx context.Context, walPath string, engine app.LocalEngi
 	}
 	// In directory mode we can skip entire segments that a committed
 	// checkpoint already covers. Legacy single-file WALs still go through
-	// the record-level skip below; loadWALRecords ignores minSegmentID for
-	// them. Legacy single-file WALs still go through the record-level skip
-	// below. Reading the checkpoint before the WAL also means a crash while
+	// the record-level skip below because they cannot skip by segment.
+	// Reading the checkpoint before the WAL also means a crash while
 	// appending a new segment cannot trick us into scanning deleted files.
 	var minSegmentID uint64
 	if hasCheckpoint {

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -621,47 +621,6 @@ func writeBytesTracked(tw *tar.Writer, manifest *Manifest, ordinal *int64, name,
 	return nil
 }
 
-func readArchive(path string, visit func(name string, data []byte) error) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return trusterr.Wrap(trusterr.CodeInternal, "open backup file", err)
-	}
-	defer f.Close()
-	var in io.Reader = f
-	if strings.HasSuffix(strings.ToLower(path), ".gz") || strings.HasSuffix(strings.ToLower(path), ".tdbackup") {
-		gz, err := gzip.NewReader(f)
-		if err == nil {
-			defer gz.Close()
-			in = gz
-		} else {
-			if _, seekErr := f.Seek(0, io.SeekStart); seekErr != nil {
-				return seekErr
-			}
-			in = f
-		}
-	}
-	tr := tar.NewReader(in)
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			return nil
-		}
-		if err != nil {
-			return trusterr.Wrap(trusterr.CodeDataLoss, "read backup archive", err)
-		}
-		if header.Typeflag != tar.TypeReg {
-			continue
-		}
-		data, err := io.ReadAll(io.LimitReader(tr, 512<<20))
-		if err != nil {
-			return trusterr.Wrap(trusterr.CodeDataLoss, "read backup entry", err)
-		}
-		if err := visit(header.Name, data); err != nil {
-			return err
-		}
-	}
-}
-
 type archiveEntry struct {
 	Name     string
 	Size     int64
@@ -858,49 +817,6 @@ func writeRestoreCheckpoint(path string, cp RestoreCheckpoint) error {
 		return err
 	}
 	return os.Rename(tmp, path)
-}
-
-func validateEntry(name string, data []byte) error {
-	switch {
-	case name == "manifest.json" || name == "summary.json":
-		var v Manifest
-		return json.Unmarshal(data, &v)
-	case strings.HasPrefix(name, "manifests/"):
-		var v model.BatchManifest
-		return cborx.UnmarshalLimit(data, &v, 128<<20)
-	case strings.HasPrefix(name, "bundles/"):
-		var v model.ProofBundle
-		return cborx.UnmarshalLimit(data, &v, 128<<20)
-	case strings.HasPrefix(name, "roots/"):
-		var v model.BatchRoot
-		return cborx.UnmarshalLimit(data, &v, 128<<20)
-	case strings.HasPrefix(name, "global/leaves/"):
-		var v model.GlobalLogLeaf
-		return cborx.UnmarshalLimit(data, &v, 128<<20)
-	case strings.HasPrefix(name, "global/nodes/"):
-		var v model.GlobalLogNode
-		return cborx.UnmarshalLimit(data, &v, 128<<20)
-	case name == "global/state.tdgstate":
-		var v model.GlobalLogState
-		return cborx.UnmarshalLimit(data, &v, 128<<20)
-	case strings.HasPrefix(name, "global/sth/"):
-		var v model.SignedTreeHead
-		return cborx.UnmarshalLimit(data, &v, 128<<20)
-	case strings.HasPrefix(name, "global/tiles/"):
-		var v model.GlobalLogTile
-		return cborx.UnmarshalLimit(data, &v, 128<<20)
-	case strings.HasPrefix(name, "anchors/sth-outbox/"):
-		var v model.STHAnchorOutboxItem
-		return cborx.UnmarshalLimit(data, &v, 128<<20)
-	case strings.HasPrefix(name, "anchors/sth-result/"):
-		var v model.STHAnchorResult
-		return cborx.UnmarshalLimit(data, &v, 128<<20)
-	case name == "checkpoint/wal.tdcheckpoint":
-		var v model.WALCheckpoint
-		return cborx.UnmarshalLimit(data, &v, 128<<20)
-	default:
-		return nil
-	}
 }
 
 func safeName(value string) string {

--- a/internal/batch/service.go
+++ b/internal/batch/service.go
@@ -64,9 +64,10 @@ type Options struct {
 	OnCheckpointAdvanced func(context.Context, model.WALCheckpoint)
 	// OnBatchCommitted fires after a batch is fully persisted (manifest
 	// committed, bundles + root written, checkpoint advanced) with the
-	// BatchRoot that was just stored. The serve command uses this hook to
-	// append the batch root to the global log and enqueue the resulting
-	// STH for L5 anchoring. The hook must not block on slow IO for the same
+	// BatchRoot that was just stored. The serve command uses this hook only
+	// to persist a durable global-log outbox event and trigger the separate
+	// outbox worker; global append and L5 anchoring must remain outside the
+	// batch goroutine. The hook must not block on slow IO for the same
 	// reason as OnCheckpointAdvanced.
 	OnBatchCommitted func(context.Context, model.BatchRoot)
 }
@@ -439,10 +440,10 @@ func (s *Service) RecoverManifest(ctx context.Context, manifest model.BatchManif
 	return nil
 }
 
-// fireOnBatchCommitted runs the commit hook in a panic-safe wrapper so
-// a buggy global-log append cannot crash the batch worker. Running
-// synchronously (same caveat as OnCheckpointAdvanced) is intentional:
-// the hook owes the caller one bounded post-commit side effect.
+// fireOnBatchCommitted runs the commit hook in a panic-safe wrapper so a buggy
+// observer cannot crash the batch worker. It is intentionally synchronous only
+// for bounded local side effects such as durable outbox enqueue; slow global
+// append, external notary calls, or network IO belong in a separate worker.
 func (s *Service) fireOnBatchCommitted(ctx context.Context, root model.BatchRoot) {
 	if s.opts.OnBatchCommitted == nil {
 		return

--- a/internal/globallog/service.go
+++ b/internal/globallog/service.go
@@ -579,21 +579,6 @@ func (s *Service) subtreeRoot(ctx context.Context, start, width uint64) ([]byte,
 	return merkle.HashNode(left, right)
 }
 
-func (s *Service) leafHashes(ctx context.Context, treeSize uint64) ([][]byte, error) {
-	hashes := make([][]byte, treeSize)
-	for i := uint64(0); i < treeSize; i++ {
-		leaf, ok, err := s.store.GetGlobalLeaf(ctx, i)
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
-			return nil, trusterr.New(trusterr.CodeNotFound, "requested STH is beyond global log size")
-		}
-		hashes[i] = append([]byte(nil), leaf.LeafHash...)
-	}
-	return hashes, nil
-}
-
 func rootFromFrontier(frontier [][]byte) ([]byte, error) {
 	var root []byte
 	for level := 0; level < len(frontier); level++ {

--- a/internal/globallog/service_test.go
+++ b/internal/globallog/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ryan-wong-coder/trustdb/internal/model"
 	"github.com/ryan-wong-coder/trustdb/internal/proofstore"
 	"github.com/ryan-wong-coder/trustdb/internal/trustcrypto"
+	"github.com/ryan-wong-coder/trustdb/internal/trusterr"
 )
 
 func newTestService(t testing.TB) (*Service, proofstore.LocalStore) {
@@ -140,7 +141,7 @@ func TestConsistencyProofMatchesSmallTreeReference(t *testing.T) {
 			t.Fatalf("AppendBatchRoot(%d): %v", i, err)
 		}
 	}
-	leaves, err := svc.leafHashes(ctx, 9)
+	leaves, err := leafHashesForReferenceTest(ctx, svc.store, 9)
 	if err != nil {
 		t.Fatalf("leafHashes: %v", err)
 	}
@@ -162,6 +163,21 @@ func TestConsistencyProofMatchesSmallTreeReference(t *testing.T) {
 			}
 		}
 	}
+}
+
+func leafHashesForReferenceTest(ctx context.Context, store Store, treeSize uint64) ([][]byte, error) {
+	hashes := make([][]byte, treeSize)
+	for i := uint64(0); i < treeSize; i++ {
+		leaf, ok, err := store.GetGlobalLeaf(ctx, i)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			return nil, trusterr.New(trusterr.CodeNotFound, "requested STH is beyond global log size")
+		}
+		hashes[i] = append([]byte(nil), leaf.LeafHash...)
+	}
+	return hashes, nil
 }
 
 func TestConsistencyProofUsesIndexedNodesInsteadOfFullLeafScan(t *testing.T) {


### PR DESCRIPTION
Fixes #6

## What changed
- Confirmed the integration timing fix from the previous CI-quality work and verified the full integration suite with low parallelism.
- Kept WAL startup recovery on the streaming replay path and cleaned a stale comment that still described the old collection-based loader.
- Removed the production-only appearance of full-leaf global consistency proof generation; the full-leaf reference helper now lives in tests only.
- Clarified the batch commit hook contract: it may enqueue a durable local outbox event, while global append and notary work stay in the outbox worker.
- Removed legacy backup archive helpers that read whole entries into memory; streaming verify/restore remains the only implementation path.
- Added a desktop regression test ensuring Wails-exposed record DTOs do not contain time.Time fields.

## Validation
- go test ./...
- go vet ./...
- go test -p 1 -count=1 -tags=integration ./...
- go test -p 1 -count=1 -tags=e2e ./...
- go test -p 1 -race ./...
- go test -p 1 -race -tags="integration e2e" ./...
- cd clients/desktop && go test ./...
- cd clients/desktop && go test -race ./...
- cd clients/desktop && go vet ./...
- cd clients/desktop/frontend && npm run build
- cd clients/desktop && wails build
- git diff --check

Note: Cursor Bugbot is intentionally not treated as a blocking TrustDB CI signal for this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to tests, comment/contract clarifications, and removal of unused backup/global-log helper code with no behavioral changes in production paths.
> 
> **Overview**
> Adds a desktop regression test that reflect-walks Wails-exposed record DTOs to ensure they don’t contain `time.Time` fields.
> 
> Cleans up stale/ambiguous documentation by clarifying WAL replay segment-skipping behavior and tightening the `OnBatchCommitted` hook contract to only allow bounded local side effects (e.g., durable outbox enqueue) while keeping global append/anchoring out of the batch worker.
> 
> Removes unused legacy backup-archive helpers that read whole entries into memory, and moves the global-log full-leaf hash scan helper out of production code into a test-only reference helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2deeaec1700d48ef767c99ddd82e3d552dacb0fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->