### PR TITLE
固化 L4/L5 证明等级状态机

### DIFF
--- a/clients/desktop/client.go
+++ b/clients/desktop/client.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/ryan-wong-coder/trustdb/internal/model"
+	"github.com/ryan-wong-coder/trustdb/internal/prooflevel"
 )
 
 // httpTimeout bounds each request against the server. Submit + proof
@@ -297,10 +298,10 @@ func looksLikeSHA256Hex(query string) bool {
 }
 
 func localRecordFromIndex(idx model.RecordIndex) LocalRecord {
-	proofLevel := "L2"
+	proofLevel := prooflevel.L2
 	var committed *model.CommittedReceipt
 	if idx.BatchID != "" {
-		proofLevel = "L3"
+		proofLevel = prooflevel.L3
 		committed = &model.CommittedReceipt{
 			SchemaVersion: model.SchemaCommittedReceipt,
 			RecordID:      idx.RecordID,
@@ -326,7 +327,7 @@ func localRecordFromIndex(idx model.RecordIndex) LocalRecord {
 		TenantID:         idx.TenantID,
 		ClientID:         idx.ClientID,
 		KeyID:            idx.KeyID,
-		ProofLevel:       proofLevel,
+		ProofLevel:       proofLevel.String(),
 		BatchID:          idx.BatchID,
 		CommittedReceipt: committed,
 	}

--- a/clients/desktop/submit.go
+++ b/clients/desktop/submit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ryan-wong-coder/trustdb/internal/anchor"
 	"github.com/ryan-wong-coder/trustdb/internal/model"
+	"github.com/ryan-wong-coder/trustdb/internal/prooflevel"
 )
 
 // SubmitRequest is the single, JSON-friendly shape the UI uses to
@@ -108,7 +109,7 @@ func (a *App) SubmitFile(req SubmitRequest) (*SubmitResult, error) {
 		TenantID:        id.TenantID,
 		ClientID:        id.ClientID,
 		KeyID:           id.KeyID,
-		ProofLevel:      "L2",
+		ProofLevel:      prooflevel.L2.String(),
 		ServerRecord:    &resp.ServerRecord,
 		AcceptedReceipt: &resp.AcceptedReceipt,
 	}
@@ -204,14 +205,16 @@ func (a *App) RefreshRecord(recordID string) (*LocalRecord, error) {
 		return &rec, err
 	}
 	cr := bundle.CommittedReceipt
-	rec.ProofLevel = "L3"
+	evidence := prooflevel.EvidenceFor(prooflevel.L3)
+	rec.ProofLevel = prooflevel.Evaluate(evidence).String()
 	rec.BatchID = cr.BatchID
 	rec.CommittedReceipt = &cr
 
 	globalProof, err := c.getGlobalProof(a.ensureCtx(), cr.BatchID)
 	if err == nil {
 		rec.GlobalProof = &globalProof
-		rec.ProofLevel = "L4"
+		evidence.GlobalLogProof = true
+		rec.ProofLevel = prooflevel.Evaluate(evidence).String()
 		anchor, err := c.getAnchor(a.ensureCtx(), globalProof.STH.TreeSize)
 		if err == nil {
 			rec.AnchorStatus = anchor.Status
@@ -219,7 +222,8 @@ func (a *App) RefreshRecord(recordID string) (*LocalRecord, error) {
 				rec.AnchorResult = anchor.Result
 				rec.AnchorSink = anchor.Result.SinkName
 				rec.AnchorID = anchor.Result.AnchorID
-				rec.ProofLevel = "L5"
+				evidence.STHAnchorResult = true
+				rec.ProofLevel = prooflevel.Evaluate(evidence).String()
 			}
 		}
 	}
@@ -350,20 +354,23 @@ func (a *App) mergeExportedProofState(recordID string, bundle model.ProofBundle,
 	}
 	rec.LastError = ""
 	setLocalRecordLastSyncedAt(&rec, time.Now().UTC())
-	rec.ProofLevel = "L3"
+	evidence := prooflevel.EvidenceFor(prooflevel.L3)
+	rec.ProofLevel = prooflevel.Evaluate(evidence).String()
 	rec.BatchID = bundle.CommittedReceipt.BatchID
 	cr := bundle.CommittedReceipt
 	rec.CommittedReceipt = &cr
 	if global != nil {
 		rec.GlobalProof = global
-		rec.ProofLevel = "L4"
+		evidence.GlobalLogProof = true
+		rec.ProofLevel = prooflevel.Evaluate(evidence).String()
 	}
 	if anchor != nil {
 		rec.AnchorResult = anchor
 		rec.AnchorStatus = model.AnchorStatePublished
 		rec.AnchorSink = anchor.SinkName
 		rec.AnchorID = anchor.AnchorID
-		rec.ProofLevel = "L5"
+		evidence.STHAnchorResult = true
+		rec.ProofLevel = prooflevel.Evaluate(evidence).String()
 	}
 	_ = st.upsertRecord(rec)
 }

--- a/cmd/trustdb/commit_cmd.go
+++ b/cmd/trustdb/commit_cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ryan-wong-coder/trustdb/internal/cborx"
 	"github.com/ryan-wong-coder/trustdb/internal/keystore"
 	"github.com/ryan-wong-coder/trustdb/internal/model"
+	"github.com/ryan-wong-coder/trustdb/internal/prooflevel"
 	"github.com/ryan-wong-coder/trustdb/internal/wal"
 	"github.com/spf13/cobra"
 )
@@ -82,7 +83,7 @@ func newCommitCommand(rt *runtimeConfig) *cobra.Command {
 			return rt.writeJSON(map[string]string{
 				"record_id": record.RecordID,
 				"proof":     outPath,
-				"level":     "L3",
+				"level":     prooflevel.L3.String(),
 			})
 		},
 	}
@@ -172,7 +173,7 @@ func newCommitBatchCommand(rt *runtimeConfig) *cobra.Command {
 				outputs[i] = map[string]string{
 					"record_id": bundles[i].RecordID,
 					"proof":     outPath,
-					"level":     "L3",
+					"level":     prooflevel.L3.String(),
 				}
 			}
 			rt.logger.Info().

--- a/internal/httpapi/handler.go
+++ b/internal/httpapi/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ryan-wong-coder/trustdb/internal/ingest"
 	"github.com/ryan-wong-coder/trustdb/internal/model"
 	"github.com/ryan-wong-coder/trustdb/internal/observability"
+	"github.com/ryan-wong-coder/trustdb/internal/prooflevel"
 	"github.com/ryan-wong-coder/trustdb/internal/trusterr"
 )
 
@@ -206,7 +207,7 @@ func (h Handler) submitClaim(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, status, submitClaimResponse{
 		RecordID:        record.RecordID,
 		Status:          accepted.Status,
-		ProofLevel:      "L2",
+		ProofLevel:      prooflevel.L2.String(),
 		Idempotent:      idempotent,
 		BatchEnqueued:   batchEnqueued,
 		BatchError:      batchErr,
@@ -228,7 +229,7 @@ func (h Handler) getProof(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, proofResponse{
 		RecordID:    bundle.RecordID,
-		ProofLevel:  "L3",
+		ProofLevel:  prooflevel.L3.String(),
 		ProofBundle: bundle,
 	})
 }
@@ -583,7 +584,7 @@ func (h Handler) getAnchor(w http.ResponseWriter, r *http.Request) {
 		writeError(w, trusterr.New(trusterr.CodeNotFound, "anchor not found for STH"))
 		return
 	}
-	resp := anchorResponse{TreeSize: treeSize, ProofLevel: "L5"}
+	resp := anchorResponse{TreeSize: treeSize, ProofLevel: prooflevel.L5.String()}
 	switch {
 	case resultOK:
 		resp.Status = model.AnchorStatePublished

--- a/internal/prooflevel/prooflevel.go
+++ b/internal/prooflevel/prooflevel.go
@@ -1,0 +1,122 @@
+// Package prooflevel defines the TrustDB L1-L5 proof ladder in one place.
+//
+// The package is intentionally pure: callers provide evidence that is already
+// present or already verified, and the evaluator returns the strongest level
+// reachable without inventing intermediate trust.
+package prooflevel
+
+type Level string
+
+const (
+	Unknown Level = ""
+	L1      Level = "L1"
+	L2      Level = "L2"
+	L3      Level = "L3"
+	L4      Level = "L4"
+	L5      Level = "L5"
+)
+
+type Evidence struct {
+	ContentHash      bool
+	ClientSignature  bool
+	AcceptedReceipt  bool
+	CommittedReceipt bool
+	BatchProof       bool
+	GlobalLogProof   bool
+	STHAnchorResult  bool
+}
+
+type Definition struct {
+	Level       Level
+	Label       string
+	Requirement string
+}
+
+var ladder = []Definition{
+	{Level: L1, Label: "local content", Requirement: "content hash matches the signed client claim and the client signature is valid"},
+	{Level: L2, Label: "accepted", Requirement: "L1 plus a valid server AcceptedReceipt"},
+	{Level: L3, Label: "batch committed", Requirement: "L2 plus a valid CommittedReceipt and batch Merkle inclusion proof"},
+	{Level: L4, Label: "global log", Requirement: "L3 plus a valid BatchRoot -> SignedTreeHead global-log inclusion proof"},
+	{Level: L5, Label: "external anchor", Requirement: "L4 plus an STH/global-root external anchor result"},
+}
+
+func Evaluate(e Evidence) Level {
+	if !(e.ContentHash && e.ClientSignature) {
+		return Unknown
+	}
+	if !e.AcceptedReceipt {
+		return L1
+	}
+	if !(e.CommittedReceipt && e.BatchProof) {
+		return L2
+	}
+	if !e.GlobalLogProof {
+		return L3
+	}
+	if !e.STHAnchorResult {
+		return L4
+	}
+	return L5
+}
+
+func EvidenceFor(level Level) Evidence {
+	evidence := Evidence{}
+	if AtLeast(level, L1) {
+		evidence.ContentHash = true
+		evidence.ClientSignature = true
+	}
+	if AtLeast(level, L2) {
+		evidence.AcceptedReceipt = true
+	}
+	if AtLeast(level, L3) {
+		evidence.CommittedReceipt = true
+		evidence.BatchProof = true
+	}
+	if AtLeast(level, L4) {
+		evidence.GlobalLogProof = true
+	}
+	if AtLeast(level, L5) {
+		evidence.STHAnchorResult = true
+	}
+	return evidence
+}
+
+func Definitions() []Definition {
+	out := make([]Definition, len(ladder))
+	copy(out, ladder)
+	return out
+}
+
+func Parse(raw string) (Level, bool) {
+	switch Level(raw) {
+	case L1, L2, L3, L4, L5:
+		return Level(raw), true
+	default:
+		return Unknown, false
+	}
+}
+
+func Rank(level Level) int {
+	switch level {
+	case L1:
+		return 1
+	case L2:
+		return 2
+	case L3:
+		return 3
+	case L4:
+		return 4
+	case L5:
+		return 5
+	default:
+		return 0
+	}
+}
+
+func AtLeast(level, target Level) bool {
+	return Rank(level) >= Rank(target) && Rank(target) > 0
+}
+
+func (l Level) String() string {
+	return string(l)
+}

--- a/internal/prooflevel/prooflevel_test.go
+++ b/internal/prooflevel/prooflevel_test.go
@@ -1,0 +1,189 @@
+package prooflevel
+
+import "testing"
+
+func TestEvaluate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   Evidence
+		want Level
+	}{
+		{
+			name: "no evidence",
+			in:   Evidence{},
+			want: Unknown,
+		},
+		{
+			name: "content without client signature is not L1",
+			in: Evidence{
+				ContentHash: true,
+			},
+			want: Unknown,
+		},
+		{
+			name: "L1 requires content hash and client signature",
+			in: Evidence{
+				ContentHash:     true,
+				ClientSignature: true,
+			},
+			want: L1,
+		},
+		{
+			name: "L2 requires accepted receipt",
+			in: Evidence{
+				ContentHash:     true,
+				ClientSignature: true,
+				AcceptedReceipt: true,
+			},
+			want: L2,
+		},
+		{
+			name: "committed receipt without batch proof stays L2",
+			in: Evidence{
+				ContentHash:      true,
+				ClientSignature:  true,
+				AcceptedReceipt:  true,
+				CommittedReceipt: true,
+			},
+			want: L2,
+		},
+		{
+			name: "L3 requires committed receipt and batch proof",
+			in: Evidence{
+				ContentHash:      true,
+				ClientSignature:  true,
+				AcceptedReceipt:  true,
+				CommittedReceipt: true,
+				BatchProof:       true,
+			},
+			want: L3,
+		},
+		{
+			name: "global proof without batch proof does not skip to L4",
+			in: Evidence{
+				ContentHash:     true,
+				ClientSignature: true,
+				AcceptedReceipt: true,
+				GlobalLogProof:  true,
+			},
+			want: L2,
+		},
+		{
+			name: "L4 requires global log proof",
+			in: Evidence{
+				ContentHash:      true,
+				ClientSignature:  true,
+				AcceptedReceipt:  true,
+				CommittedReceipt: true,
+				BatchProof:       true,
+				GlobalLogProof:   true,
+			},
+			want: L4,
+		},
+		{
+			name: "anchor without global proof stays L3",
+			in: Evidence{
+				ContentHash:      true,
+				ClientSignature:  true,
+				AcceptedReceipt:  true,
+				CommittedReceipt: true,
+				BatchProof:       true,
+				STHAnchorResult:  true,
+			},
+			want: L3,
+		},
+		{
+			name: "L5 requires global proof and STH anchor result",
+			in: Evidence{
+				ContentHash:      true,
+				ClientSignature:  true,
+				AcceptedReceipt:  true,
+				CommittedReceipt: true,
+				BatchProof:       true,
+				GlobalLogProof:   true,
+				STHAnchorResult:  true,
+			},
+			want: L5,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := Evaluate(tt.in); got != tt.want {
+				t.Fatalf("Evaluate() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRankAndAtLeast(t *testing.T) {
+	t.Parallel()
+
+	if Rank(Unknown) != 0 {
+		t.Fatalf("Rank(Unknown) = %d, want 0", Rank(Unknown))
+	}
+	if !AtLeast(L5, L4) {
+		t.Fatalf("AtLeast(L5, L4) = false, want true")
+	}
+	if AtLeast(L3, L4) {
+		t.Fatalf("AtLeast(L3, L4) = true, want false")
+	}
+	if AtLeast(Unknown, L1) {
+		t.Fatalf("AtLeast(Unknown, L1) = true, want false")
+	}
+}
+
+func TestEvidenceForRoundTripsThroughEvaluate(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name  string
+		level Level
+	}{
+		{name: "unknown", level: Unknown},
+		{name: "L1", level: L1},
+		{name: "L2", level: L2},
+		{name: "L3", level: L3},
+		{name: "L4", level: L4},
+		{name: "L5", level: L5},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := Evaluate(EvidenceFor(tt.level)); got != tt.level {
+				t.Fatalf("Evaluate(EvidenceFor(%s)) = %s, want %s", tt.level, got, tt.level)
+			}
+		})
+	}
+}
+
+func TestDefinitionsReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	defs := Definitions()
+	if len(defs) != 5 {
+		t.Fatalf("Definitions len = %d, want 5", len(defs))
+	}
+	defs[0].Level = L5
+	if Definitions()[0].Level != L1 {
+		t.Fatalf("Definitions returned mutable package state")
+	}
+}
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{"L1", "L2", "L3", "L4", "L5"} {
+		got, ok := Parse(raw)
+		if !ok || got.String() != raw {
+			t.Fatalf("Parse(%q) = %q, %v", raw, got, ok)
+		}
+	}
+	if got, ok := Parse("L6"); ok || got != Unknown {
+		t.Fatalf("Parse(L6) = %q, %v, want unknown false", got, ok)
+	}
+}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ryan-wong-coder/trustdb/internal/globallog"
 	"github.com/ryan-wong-coder/trustdb/internal/merkle"
 	"github.com/ryan-wong-coder/trustdb/internal/model"
+	"github.com/ryan-wong-coder/trustdb/internal/prooflevel"
 	"github.com/ryan-wong-coder/trustdb/internal/receipt"
 	"github.com/ryan-wong-coder/trustdb/internal/trustcrypto"
 )
@@ -20,12 +21,8 @@ type TrustedKeys struct {
 	ServerPublicKey ed25519.PublicKey
 }
 
-// Result is the outcome of ProofBundle. ProofLevel reflects the
-// highest level that was successfully verified:
-//
-//   - "L3" — content, signatures and merkle proof all match.
-//   - "L4" — the committed batch root is included in a global STH.
-//   - "L5" — that same STH/global root is externally anchored.
+// Result is the outcome of ProofBundle. ProofLevel follows the centralized
+// prooflevel ladder so CLI, desktop and future SDK code do not drift.
 type Result struct {
 	Valid      bool   `json:"valid"`
 	RecordID   string `json:"record_id"`
@@ -106,16 +103,18 @@ func ProofBundle(raw io.Reader, bundle model.ProofBundle, keys TrustedKeys, opts
 	) {
 		return Result{}, fmt.Errorf("verify: merkle proof failed")
 	}
+	evidence := prooflevel.EvidenceFor(prooflevel.L3)
 	result := Result{
 		Valid:      true,
 		RecordID:   verified.RecordID,
-		ProofLevel: "L3",
+		ProofLevel: prooflevel.Evaluate(evidence).String(),
 	}
 	if o.global != nil {
 		if err := GlobalLogConsistency(bundle, *o.global); err != nil {
 			return Result{}, err
 		}
-		result.ProofLevel = "L4"
+		evidence.GlobalLogProof = true
+		result.ProofLevel = prooflevel.Evaluate(evidence).String()
 	}
 	if o.anchor != nil {
 		if o.global == nil {
@@ -124,7 +123,8 @@ func ProofBundle(raw io.Reader, bundle model.ProofBundle, keys TrustedKeys, opts
 		if err := AnchorConsistency(*o.global, *o.anchor); err != nil {
 			return Result{}, err
 		}
-		result.ProofLevel = "L5"
+		evidence.STHAnchorResult = true
+		result.ProofLevel = prooflevel.Evaluate(evidence).String()
 		result.AnchorSink = o.anchor.SinkName
 		result.AnchorID = o.anchor.AnchorID
 	}


### PR DESCRIPTION
Fixes #18

## 变更内容
- 新增 `internal/prooflevel`，集中定义 L1-L5 等级、等级顺序、证据条件和状态机评估逻辑。
- 将 `verify.ProofBundle` 的 L3/L4/L5 结果改为通过统一状态机计算。
- 将 HTTP API、CLI commit 输出、桌面客户端远程记录投影和刷新逻辑里的等级字符串接入统一状态机。
- 增加状态机单元测试，覆盖缺失中间证据时不能跳级，例如 anchor 存在但没有 GlobalLogProof 时不能成为 L5。

## 验证
- `go test ./...`
- `go vet ./...`
- `go test -p 1 -count=1 -tags=integration ./...`
- `go test -p 1 -race ./...`
- `cd clients/desktop && go test ./...`
- `cd clients/desktop && go vet ./...`
- `cd clients/desktop && go test -p 1 -race ./...`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proof-level reporting across the HTTP API, verifier, CLI output, and desktop client refresh logic; mis-modeling evidence or incorrect wiring could cause incorrect L3/L4/L5 status being reported to users.
> 
> **Overview**
> **Centralizes TrustDB proof-level (L1–L5) logic** into a new `internal/prooflevel` package, defining the ladder, ordering, evidence requirements, and an evaluator to prevent skipping levels.
> 
> Updates the desktop client, HTTP API responses, CLI `commit` output, and `verify.ProofBundle` to stop hardcoding `"L2"/"L3"/"L4"/"L5"` strings and instead compute/report levels via `prooflevel.Evaluate` (including refresh/merge paths that advance from L3→L4→L5 only when corresponding evidence is present).
> 
> Adds unit tests for the proof-level state machine to ensure missing intermediate evidence cannot incorrectly promote to higher levels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9d171fe6db0ee8954144e374cdd8e19539df6cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->