### PR TITLE
新增 TrustDB Go SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ License: AGPL-3.0-only. See [LICENSE](LICENSE).
 - Proofstore backends for local file storage and Pebble; the production profile uses Pebble.
 - Paginated server-side record and root APIs with cursor/range-oriented access paths.
 - Portable `.tdbackup` create, verify, and resumable restore flow.
+- Public Go SDK for claim signing, server calls, proof export, and local verification.
 - Desktop client built with Wails + Vue that supports onboarding, local identity, server settings, file attestation, record management, proof refresh, local verification, and `.sproof` export.
 - Desktop local record storage backed by Pebble with indexes for list/search/filter paths.
 
@@ -205,6 +206,36 @@ cd clients/desktop
 go test ./...
 cd frontend
 npm run build
+```
+
+## Go SDK
+
+The public Go SDK lives in `sdk` and is imported as:
+
+```go
+import "github.com/ryan-wong-coder/trustdb/sdk"
+```
+
+Current SDK capabilities:
+
+- build and sign file claims with Ed25519;
+- submit signed claims to `POST /v1/claims`;
+- query records, proof bundles, STHs, GlobalLogProof, and STH anchor state;
+- export the recommended `.sproof` single-file proof;
+- verify `.sproof` and split proof artifacts locally.
+
+Minimal example:
+
+```go
+client, err := sdk.NewClient("http://127.0.0.1:8080")
+if err != nil {
+    return err
+}
+proof, err := client.ExportSingleProof(ctx, recordID)
+if err != nil {
+    return err
+}
+return sdk.WriteSingleProofFile("example.sproof", proof)
 ```
 
 ## Development Checks

--- a/sdk/claim.go
+++ b/sdk/claim.go
@@ -1,0 +1,104 @@
+package sdk
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/ryan-wong-coder/trustdb/internal/claim"
+	"github.com/ryan-wong-coder/trustdb/internal/model"
+	"github.com/ryan-wong-coder/trustdb/internal/trustcrypto"
+)
+
+func BuildSignedFileClaim(raw io.Reader, id Identity, opts FileClaimOptions) (SignedClaim, error) {
+	if raw == nil {
+		return SignedClaim{}, errors.New("sdk: raw content reader is nil")
+	}
+	if len(id.PrivateKey) != trustcrypto.Ed25519PrivateKeySize {
+		return SignedClaim{}, fmt.Errorf("sdk: invalid ed25519 private key size: %d", len(id.PrivateKey))
+	}
+	hashAlg := opts.HashAlg
+	if hashAlg == "" {
+		hashAlg = model.DefaultHashAlg
+	}
+	contentHash, n, err := trustcrypto.HashReader(hashAlg, raw)
+	if err != nil {
+		return SignedClaim{}, err
+	}
+	producedAt := opts.ProducedAt
+	if producedAt.IsZero() {
+		producedAt = time.Now().UTC()
+	}
+	nonce := append([]byte(nil), opts.Nonce...)
+	if len(nonce) == 0 {
+		nonce, err = trustcrypto.NewNonce(16)
+		if err != nil {
+			return SignedClaim{}, err
+		}
+	}
+	idempotencyKey := opts.IdempotencyKey
+	if idempotencyKey == "" {
+		idempotencyKey, err = randomIdempotencyKey()
+		if err != nil {
+			return SignedClaim{}, err
+		}
+	}
+	eventType := opts.EventType
+	if eventType == "" {
+		eventType = "file.snapshot"
+	}
+	metadata := model.Metadata{
+		EventType: eventType,
+		Source:    opts.Source,
+		Custom:    copyStringMap(opts.CustomMetadata),
+	}
+	content := model.Content{
+		HashAlg:       hashAlg,
+		ContentHash:   contentHash,
+		ContentLength: n,
+		MediaType:     opts.MediaType,
+		StorageURI:    opts.StorageURI,
+	}
+	c, err := claim.NewFileClaim(
+		id.TenantID,
+		id.ClientID,
+		id.KeyID,
+		producedAt,
+		nonce,
+		idempotencyKey,
+		content,
+		metadata,
+	)
+	if err != nil {
+		return SignedClaim{}, err
+	}
+	return claim.Sign(c, id.PrivateKey)
+}
+
+func VerifySignedClaim(signed SignedClaim, publicKey ed25519.PublicKey) (string, error) {
+	verified, err := claim.Verify(signed, publicKey)
+	if err != nil {
+		return "", err
+	}
+	return verified.RecordID, nil
+}
+
+func randomIdempotencyKey() (string, error) {
+	raw := make([]byte, 18)
+	if _, err := io.ReadFull(rand.Reader, raw); err != nil {
+		return "", fmt.Errorf("sdk: generate idempotency key: %w", err)
+	}
+	return "sdk-" + base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+func copyStringMap(in map[string]string) map[string]string {
+	out := map[string]string{}
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/sdk/claim_test.go
+++ b/sdk/claim_test.go
@@ -1,0 +1,53 @@
+package sdk
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/ryan-wong-coder/trustdb/internal/model"
+	"github.com/ryan-wong-coder/trustdb/internal/trustcrypto"
+)
+
+func TestBuildSignedFileClaimDefaultsAndVerifies(t *testing.T) {
+	t.Parallel()
+
+	pub, priv, err := trustcrypto.GenerateEd25519Key()
+	if err != nil {
+		t.Fatalf("GenerateEd25519Key: %v", err)
+	}
+	signed, err := BuildSignedFileClaim(bytes.NewReader([]byte("hello trustdb")), Identity{
+		TenantID:   "tenant-1",
+		ClientID:   "client-1",
+		KeyID:      "client-key-1",
+		PrivateKey: priv,
+	}, FileClaimOptions{
+		ProducedAt:     time.Unix(10, 0),
+		Nonce:          bytes.Repeat([]byte{0x42}, 16),
+		IdempotencyKey: "idem-1",
+		MediaType:      "text/plain",
+		StorageURI:     "file:///tmp/hello.txt",
+		EventType:      "file.snapshot",
+		Source:         "sdk-test",
+		CustomMetadata: map[string]string{"file_name": "hello.txt"},
+	})
+	if err != nil {
+		t.Fatalf("BuildSignedFileClaim: %v", err)
+	}
+	recordID, err := VerifySignedClaim(signed, pub)
+	if err != nil {
+		t.Fatalf("VerifySignedClaim: %v", err)
+	}
+	if recordID == "" {
+		t.Fatal("record id is empty")
+	}
+	if signed.SchemaVersion != model.SchemaSignedClaim {
+		t.Fatalf("schema = %q", signed.SchemaVersion)
+	}
+	if got := signed.Claim.Content.ContentLength; got != int64(len("hello trustdb")) {
+		t.Fatalf("content length = %d", got)
+	}
+	if got := signed.Claim.Metadata.Custom["file_name"]; got != "hello.txt" {
+		t.Fatalf("metadata file_name = %q", got)
+	}
+}

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -1,0 +1,348 @@
+package sdk
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ryan-wong-coder/trustdb/internal/cborx"
+	"github.com/ryan-wong-coder/trustdb/internal/model"
+	"github.com/ryan-wong-coder/trustdb/internal/sproof"
+)
+
+const defaultHTTPTimeout = 15 * time.Second
+
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+	userAgent  string
+}
+
+type Option func(*Client)
+
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *Client) {
+		if client != nil {
+			c.httpClient = client
+		}
+	}
+}
+
+func WithUserAgent(userAgent string) Option {
+	return func(c *Client) {
+		c.userAgent = strings.TrimSpace(userAgent)
+	}
+}
+
+func NewClient(baseURL string, opts ...Option) (*Client, error) {
+	trimmed := strings.TrimSpace(baseURL)
+	if trimmed == "" {
+		return nil, errors.New("sdk: server url is empty")
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("sdk: parse server url: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("sdk: server url must include scheme and host: %s", trimmed)
+	}
+	c := &Client{
+		baseURL: strings.TrimRight(trimmed, "/"),
+		httpClient: &http.Client{
+			Timeout: defaultHTTPTimeout,
+		},
+		userAgent: "trustdb-go-sdk",
+	}
+	for _, apply := range opts {
+		apply(c)
+	}
+	return c, nil
+}
+
+func (c *Client) Health(ctx context.Context) error {
+	var out struct {
+		OK bool `json:"ok"`
+	}
+	if err := c.getJSON(ctx, "/healthz", nil, &out); err != nil {
+		return err
+	}
+	if !out.OK {
+		return &Error{Op: "health", Message: "server returned ok=false"}
+	}
+	return nil
+}
+
+func (c *Client) SubmitFile(ctx context.Context, raw io.Reader, id Identity, opts FileClaimOptions) (SubmitResult, error) {
+	signed, err := BuildSignedFileClaim(raw, id, opts)
+	if err != nil {
+		return SubmitResult{}, err
+	}
+	result, err := c.SubmitSignedClaim(ctx, signed)
+	if err != nil {
+		return SubmitResult{}, err
+	}
+	result.SignedClaim = signed
+	return result, nil
+}
+
+func (c *Client) SubmitSignedClaim(ctx context.Context, signed SignedClaim) (SubmitResult, error) {
+	body, err := cborx.Marshal(signed)
+	if err != nil {
+		return SubmitResult{}, err
+	}
+	var env submitClaimEnvelope
+	if err := c.doJSON(ctx, http.MethodPost, "/v1/claims", nil, bytes.NewReader(body), "application/cbor", &env); err != nil {
+		return SubmitResult{}, err
+	}
+	return SubmitResult{
+		RecordID:        env.RecordID,
+		Status:          env.Status,
+		ProofLevel:      env.ProofLevel,
+		Idempotent:      env.Idempotent,
+		BatchEnqueued:   env.BatchEnqueued,
+		BatchError:      env.BatchError,
+		ServerRecord:    env.ServerRecord,
+		AcceptedReceipt: env.AcceptedReceipt,
+		SignedClaim:     signed,
+	}, nil
+}
+
+func (c *Client) GetRecord(ctx context.Context, recordID string) (RecordIndex, error) {
+	var idx model.RecordIndex
+	if err := c.getJSON(ctx, "/v1/records/"+url.PathEscape(recordID), nil, &idx); err != nil {
+		return RecordIndex{}, err
+	}
+	if idx.RecordID == "" {
+		return RecordIndex{}, &Error{Op: "get record", Message: "server returned empty record index"}
+	}
+	return idx, nil
+}
+
+func (c *Client) ListRecords(ctx context.Context, opts ListRecordsOptions) (RecordPage, error) {
+	values := url.Values{}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	values.Set("limit", strconv.Itoa(limit))
+	direction := opts.Direction
+	if direction == "" {
+		direction = model.RecordListDirectionDesc
+	}
+	values.Set("direction", direction)
+	setQuery(values, "cursor", opts.Cursor)
+	setQuery(values, "batch_id", opts.BatchID)
+	setQuery(values, "tenant_id", opts.TenantID)
+	setQuery(values, "client_id", opts.ClientID)
+	setQuery(values, "q", opts.Query)
+	setQuery(values, "content_hash", opts.ContentHashHex)
+	if opts.ReceivedFromUnixN > 0 {
+		values.Set("received_from", strconv.FormatInt(opts.ReceivedFromUnixN, 10))
+	}
+	if opts.ReceivedToUnixN > 0 {
+		values.Set("received_to", strconv.FormatInt(opts.ReceivedToUnixN, 10))
+	}
+	var env recordsEnvelope
+	if err := c.getJSON(ctx, "/v1/records", values, &env); err != nil {
+		return RecordPage{}, err
+	}
+	records := make([]RecordIndex, 0, len(env.Records))
+	records = append(records, env.Records...)
+	return RecordPage{
+		Records:    records,
+		Limit:      env.Limit,
+		Direction:  env.Direction,
+		NextCursor: env.NextCursor,
+	}, nil
+}
+
+func (c *Client) GetProofBundle(ctx context.Context, recordID string) (ProofBundle, error) {
+	var env proofEnvelope
+	if err := c.getJSON(ctx, "/v1/proofs/"+url.PathEscape(recordID), nil, &env); err != nil {
+		return ProofBundle{}, err
+	}
+	if env.ProofBundle.RecordID == "" {
+		return ProofBundle{}, &Error{Op: "get proof bundle", Message: "server returned empty proof bundle"}
+	}
+	return env.ProofBundle, nil
+}
+
+func (c *Client) GetGlobalProof(ctx context.Context, batchID string) (GlobalLogProof, error) {
+	var proof model.GlobalLogProof
+	if err := c.getJSON(ctx, "/v1/global-log/inclusion/"+url.PathEscape(batchID), nil, &proof); err != nil {
+		return GlobalLogProof{}, err
+	}
+	return proof, nil
+}
+
+func (c *Client) GetAnchor(ctx context.Context, treeSize uint64) (AnchorStatus, error) {
+	var env anchorEnvelope
+	if err := c.getJSON(ctx, "/v1/anchors/sth/"+strconv.FormatUint(treeSize, 10), nil, &env); err != nil {
+		return AnchorStatus{}, err
+	}
+	return AnchorStatus{
+		TreeSize: env.TreeSize,
+		Status:   env.Status,
+		Result:   env.Result,
+	}, nil
+}
+
+func (c *Client) LatestSTH(ctx context.Context) (SignedTreeHead, error) {
+	var sth model.SignedTreeHead
+	if err := c.getJSON(ctx, "/v1/sth/latest", nil, &sth); err != nil {
+		return SignedTreeHead{}, err
+	}
+	return sth, nil
+}
+
+func (c *Client) GetSTH(ctx context.Context, treeSize uint64) (SignedTreeHead, error) {
+	var sth model.SignedTreeHead
+	if err := c.getJSON(ctx, "/v1/sth/"+strconv.FormatUint(treeSize, 10), nil, &sth); err != nil {
+		return SignedTreeHead{}, err
+	}
+	return sth, nil
+}
+
+func (c *Client) ExportSingleProof(ctx context.Context, recordID string) (SingleProof, error) {
+	bundle, err := c.GetProofBundle(ctx, recordID)
+	if err != nil {
+		return SingleProof{}, err
+	}
+	opts := sproof.Options{ExportedAtUnixN: time.Now().UTC().UnixNano()}
+	global, err := c.GetGlobalProof(ctx, bundle.CommittedReceipt.BatchID)
+	if err != nil {
+		if !IsUnavailable(err) {
+			return SingleProof{}, fmt.Errorf("sdk: fetch global proof: %w", err)
+		}
+		return sproof.New(bundle, opts)
+	}
+	opts.GlobalProof = &global
+	anchor, err := c.GetAnchor(ctx, global.STH.TreeSize)
+	if err != nil {
+		if !IsUnavailable(err) {
+			return SingleProof{}, fmt.Errorf("sdk: fetch anchor: %w", err)
+		}
+		return sproof.New(bundle, opts)
+	}
+	opts.AnchorResult = anchor.Result
+	return sproof.New(bundle, opts)
+}
+
+func (c *Client) WriteSingleProofFile(ctx context.Context, recordID, path string) error {
+	proof, err := c.ExportSingleProof(ctx, recordID)
+	if err != nil {
+		return err
+	}
+	return sproof.WriteFile(path, proof)
+}
+
+func (c *Client) getJSON(ctx context.Context, path string, query url.Values, dst any) error {
+	return c.doJSON(ctx, http.MethodGet, path, query, nil, "", dst)
+}
+
+func (c *Client) doJSON(
+	ctx context.Context,
+	method string,
+	path string,
+	query url.Values,
+	body io.Reader,
+	contentType string,
+	dst any,
+) error {
+	endpoint := c.baseURL + path
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return &Error{Op: method, URL: endpoint, Err: err}
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return &Error{Op: method, URL: endpoint, Err: err}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return decodeHTTPError(method, endpoint, resp)
+	}
+	if dst == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		return &Error{Op: method, URL: endpoint, Err: fmt.Errorf("decode json: %w", err)}
+	}
+	return nil
+}
+
+func decodeHTTPError(method, endpoint string, resp *http.Response) error {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 16<<10))
+	var env struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &env); err == nil && (env.Code != "" || env.Message != "") {
+		return &Error{
+			Op:         method,
+			URL:        endpoint,
+			StatusCode: resp.StatusCode,
+			Code:       env.Code,
+			Message:    env.Message,
+		}
+	}
+	return &Error{
+		Op:         method,
+		URL:        endpoint,
+		StatusCode: resp.StatusCode,
+		Message:    strings.TrimSpace(string(body)),
+	}
+}
+
+func setQuery(values url.Values, name, value string) {
+	if strings.TrimSpace(value) != "" {
+		values.Set(name, value)
+	}
+}
+
+type submitClaimEnvelope struct {
+	RecordID        string          `json:"record_id"`
+	Status          string          `json:"status"`
+	ProofLevel      string          `json:"proof_level"`
+	Idempotent      bool            `json:"idempotent"`
+	BatchEnqueued   bool            `json:"batch_enqueued"`
+	BatchError      string          `json:"batch_error,omitempty"`
+	ServerRecord    ServerRecord    `json:"server_record"`
+	AcceptedReceipt AcceptedReceipt `json:"accepted_receipt"`
+}
+
+type proofEnvelope struct {
+	RecordID    string      `json:"record_id"`
+	ProofLevel  string      `json:"proof_level"`
+	ProofBundle ProofBundle `json:"proof_bundle"`
+}
+
+type recordsEnvelope struct {
+	Records    []RecordIndex `json:"records"`
+	Limit      int           `json:"limit"`
+	Direction  string        `json:"direction"`
+	NextCursor string        `json:"next_cursor,omitempty"`
+}
+
+type anchorEnvelope struct {
+	TreeSize uint64           `json:"tree_size"`
+	Status   string           `json:"status"`
+	Result   *STHAnchorResult `json:"result,omitempty"`
+}

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -1,0 +1,201 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ryan-wong-coder/trustdb/internal/cborx"
+	"github.com/ryan-wong-coder/trustdb/internal/model"
+	"github.com/ryan-wong-coder/trustdb/internal/trusterr"
+)
+
+func TestClientSubmitSignedClaim(t *testing.T) {
+	t.Parallel()
+
+	signed := SignedClaim{
+		SchemaVersion: model.SchemaSignedClaim,
+		Claim: model.ClientClaim{
+			SchemaVersion:  model.SchemaClientClaim,
+			TenantID:       "tenant-1",
+			ClientID:       "client-1",
+			KeyID:          "key-1",
+			IdempotencyKey: "idem-1",
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/claims" {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/cbor" {
+			t.Fatalf("Content-Type = %q", got)
+		}
+		if got := r.Header.Get("User-Agent"); got != "trustdb-go-sdk" {
+			t.Fatalf("User-Agent = %q", got)
+		}
+		var decoded SignedClaim
+		if err := cborx.DecodeReaderLimit(r.Body, &decoded, 1<<20); err != nil {
+			t.Fatalf("DecodeReaderLimit: %v", err)
+		}
+		if decoded.Claim.IdempotencyKey != "idem-1" {
+			t.Fatalf("decoded claim = %+v", decoded.Claim)
+		}
+		writeJSONForTest(t, w, http.StatusAccepted, submitClaimEnvelope{
+			RecordID:      "tr1record",
+			Status:        "accepted",
+			ProofLevel:    ProofLevelL2,
+			BatchEnqueued: true,
+			ServerRecord: ServerRecord{
+				SchemaVersion: model.SchemaServerRecord,
+				RecordID:      "tr1record",
+			},
+			AcceptedReceipt: AcceptedReceipt{
+				SchemaVersion: model.SchemaAcceptedReceipt,
+				RecordID:      "tr1record",
+				Status:        "accepted",
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	result, err := client.SubmitSignedClaim(context.Background(), signed)
+	if err != nil {
+		t.Fatalf("SubmitSignedClaim: %v", err)
+	}
+	if result.RecordID != "tr1record" || result.ProofLevel != ProofLevelL2 || !result.BatchEnqueued {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
+func TestClientListRecordsEncodesQuery(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/records" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		query := r.URL.Query()
+		if query.Get("limit") != "25" ||
+			query.Get("direction") != "asc" ||
+			query.Get("batch_id") != "batch-1" ||
+			query.Get("q") != "hello" {
+			t.Fatalf("query = %s", r.URL.RawQuery)
+		}
+		writeJSONForTest(t, w, http.StatusOK, recordsEnvelope{
+			Records: []RecordIndex{{
+				SchemaVersion: model.SchemaRecordIndex,
+				RecordID:      "tr1record",
+				BatchID:       "batch-1",
+			}},
+			Limit:      25,
+			Direction:  "asc",
+			NextCursor: "next",
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	page, err := client.ListRecords(context.Background(), ListRecordsOptions{
+		Limit:     25,
+		Direction: RecordListDirectionAsc,
+		BatchID:   "batch-1",
+		Query:     "hello",
+	})
+	if err != nil {
+		t.Fatalf("ListRecords: %v", err)
+	}
+	if len(page.Records) != 1 || page.NextCursor != "next" {
+		t.Fatalf("page = %+v", page)
+	}
+}
+
+func TestClientExportSingleProofFallsBackToL3WhenGlobalProofUnavailable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/proofs/tr1record":
+			writeJSONForTest(t, w, http.StatusOK, proofEnvelope{
+				RecordID:   "tr1record",
+				ProofLevel: ProofLevelL3,
+				ProofBundle: ProofBundle{
+					SchemaVersion: model.SchemaProofBundle,
+					RecordID:      "tr1record",
+					CommittedReceipt: CommittedReceipt{
+						BatchID: "batch-1",
+					},
+				},
+			})
+		case r.URL.Path == "/v1/global-log/inclusion/batch-1":
+			writeJSONForTest(t, w, http.StatusNotFound, map[string]string{
+				"code":    string(trusterr.CodeNotFound),
+				"message": "global proof not found",
+			})
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	proof, err := client.ExportSingleProof(context.Background(), "tr1record")
+	if err != nil {
+		t.Fatalf("ExportSingleProof: %v", err)
+	}
+	if proof.RecordID != "tr1record" || proof.ProofLevel != ProofLevelL3 || proof.GlobalProof != nil {
+		t.Fatalf("proof = %+v", proof)
+	}
+}
+
+func TestClientErrorIsDiagnosable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSONForTest(t, w, http.StatusConflict, map[string]string{
+			"code":    string(trusterr.CodeAlreadyExists),
+			"message": "duplicate claim",
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	_, err = client.GetProofBundle(context.Background(), "tr1record")
+	if err == nil {
+		t.Fatal("GetProofBundle error = nil, want conflict")
+	}
+	var sdkErr *Error
+	if !errors.As(err, &sdkErr) {
+		t.Fatalf("error type = %T, want *sdk.Error", err)
+	}
+	if sdkErr.StatusCode != http.StatusConflict ||
+		sdkErr.Code != string(trusterr.CodeAlreadyExists) ||
+		!strings.Contains(sdkErr.Error(), "duplicate claim") {
+		t.Fatalf("sdk error = %+v", sdkErr)
+	}
+}
+
+func writeJSONForTest(t *testing.T, w http.ResponseWriter, status int, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+}

--- a/sdk/doc.go
+++ b/sdk/doc.go
@@ -1,0 +1,6 @@
+// Package sdk is the public Go client for TrustDB.
+//
+// It exposes domain-level helpers for building signed file claims, submitting
+// them to a TrustDB server, fetching proof artifacts, exporting .sproof files,
+// and verifying proof material without hand-writing HTTP calls.
+package sdk

--- a/sdk/errors.go
+++ b/sdk/errors.go
@@ -1,0 +1,59 @@
+package sdk
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/ryan-wong-coder/trustdb/internal/trusterr"
+)
+
+type Error struct {
+	Op         string
+	URL        string
+	StatusCode int
+	Code       string
+	Message    string
+	Err        error
+}
+
+func (e *Error) Error() string {
+	prefix := e.Op
+	if e.URL != "" {
+		prefix += " " + e.URL
+	}
+	switch {
+	case e.Err != nil && e.Message != "":
+		return fmt.Sprintf("%s: %s: %v", prefix, e.Message, e.Err)
+	case e.Err != nil:
+		return fmt.Sprintf("%s: %v", prefix, e.Err)
+	case e.Code != "" && e.Message != "":
+		return fmt.Sprintf("%s: %s: %s", prefix, e.Code, e.Message)
+	case e.Message != "":
+		return fmt.Sprintf("%s: %s", prefix, e.Message)
+	case e.StatusCode != 0:
+		return fmt.Sprintf("%s: http status %d", prefix, e.StatusCode)
+	default:
+		return prefix
+	}
+}
+
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
+func IsNotFound(err error) bool {
+	var sdkErr *Error
+	return errors.As(err, &sdkErr) && sdkErr.StatusCode == http.StatusNotFound
+}
+
+func IsUnavailable(err error) bool {
+	var sdkErr *Error
+	if !errors.As(err, &sdkErr) {
+		return false
+	}
+	return sdkErr.StatusCode == http.StatusNotFound ||
+		sdkErr.StatusCode == http.StatusPreconditionFailed ||
+		sdkErr.Code == string(trusterr.CodeNotFound) ||
+		sdkErr.Code == string(trusterr.CodeFailedPrecondition)
+}

--- a/sdk/example_test.go
+++ b/sdk/example_test.go
@@ -1,0 +1,48 @@
+package sdk_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"fmt"
+	"testing"
+
+	"github.com/ryan-wong-coder/trustdb/sdk"
+)
+
+func TestPublicModelAliasesCompile(t *testing.T) {
+	t.Parallel()
+
+	proof := sdk.ProofBundle{SchemaVersion: "trustdb.proof-bundle.v1", RecordID: "tr1example"}
+	single := sdk.SingleProof{SchemaVersion: "trustdb.sproof.v1", RecordID: proof.RecordID, ProofBundle: proof}
+	if single.ProofBundle.RecordID != "tr1example" {
+		t.Fatalf("single proof = %+v", single)
+	}
+}
+
+func ExampleClient_ExportSingleProof() {
+	client, err := sdk.NewClient("http://127.0.0.1:8080")
+	if err != nil {
+		panic(err)
+	}
+	_, _ = client.ExportSingleProof(context.Background(), "tr1example")
+}
+
+func ExampleBuildSignedFileClaim() {
+	_, privateKey, _ := ed25519.GenerateKey(bytes.NewReader(bytes.Repeat([]byte{1}, 64)))
+	signed, err := sdk.BuildSignedFileClaim(bytes.NewReader([]byte("hello")), sdk.Identity{
+		TenantID:   "tenant",
+		ClientID:   "client",
+		KeyID:      "client-key",
+		PrivateKey: privateKey,
+	}, sdk.FileClaimOptions{
+		IdempotencyKey: "demo-idempotency-key",
+		Nonce:          bytes.Repeat([]byte{2}, 16),
+		EventType:      "file.snapshot",
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(signed.SchemaVersion)
+	// Output: trustdb.signed-claim.v1
+}

--- a/sdk/types.go
+++ b/sdk/types.go
@@ -1,0 +1,114 @@
+package sdk
+
+import (
+	"crypto/ed25519"
+	"time"
+
+	"github.com/ryan-wong-coder/trustdb/internal/model"
+)
+
+type ClientClaim = model.ClientClaim
+type SignedClaim = model.SignedClaim
+type Content = model.Content
+type Metadata = model.Metadata
+type ServerRecord = model.ServerRecord
+type AcceptedReceipt = model.AcceptedReceipt
+type CommittedReceipt = model.CommittedReceipt
+type ProofBundle = model.ProofBundle
+type RecordIndex = model.RecordIndex
+type BatchRoot = model.BatchRoot
+type SignedTreeHead = model.SignedTreeHead
+type GlobalLogProof = model.GlobalLogProof
+type STHAnchorResult = model.STHAnchorResult
+type SingleProof = model.SingleProof
+
+const (
+	ProofLevelL1 = "L1"
+	ProofLevelL2 = "L2"
+	ProofLevelL3 = "L3"
+	ProofLevelL4 = "L4"
+	ProofLevelL5 = "L5"
+
+	RecordListDirectionAsc  = model.RecordListDirectionAsc
+	RecordListDirectionDesc = model.RecordListDirectionDesc
+)
+
+type Identity struct {
+	TenantID   string
+	ClientID   string
+	KeyID      string
+	PrivateKey ed25519.PrivateKey
+}
+
+type FileClaimOptions struct {
+	ProducedAt     time.Time
+	Nonce          []byte
+	IdempotencyKey string
+	HashAlg        string
+	MediaType      string
+	StorageURI     string
+	EventType      string
+	Source         string
+	CustomMetadata map[string]string
+}
+
+type SubmitResult struct {
+	RecordID        string
+	Status          string
+	ProofLevel      string
+	Idempotent      bool
+	BatchEnqueued   bool
+	BatchError      string
+	ServerRecord    ServerRecord
+	AcceptedReceipt AcceptedReceipt
+	SignedClaim     SignedClaim
+}
+
+type ListRecordsOptions struct {
+	Limit             int
+	Direction         string
+	Cursor            string
+	BatchID           string
+	TenantID          string
+	ClientID          string
+	Query             string
+	ContentHashHex    string
+	ReceivedFromUnixN int64
+	ReceivedToUnixN   int64
+}
+
+type RecordPage struct {
+	Records    []RecordIndex
+	Limit      int
+	Direction  string
+	NextCursor string
+}
+
+type AnchorStatus struct {
+	TreeSize uint64
+	Status   string
+	Result   *STHAnchorResult
+}
+
+type TrustedKeys struct {
+	ClientPublicKey ed25519.PublicKey
+	ServerPublicKey ed25519.PublicKey
+}
+
+type VerifyOptions struct {
+	SkipAnchor bool
+}
+
+type ProofArtifacts struct {
+	Bundle       ProofBundle
+	GlobalProof  *GlobalLogProof
+	AnchorResult *STHAnchorResult
+}
+
+type VerifyResult struct {
+	Valid      bool
+	RecordID   string
+	ProofLevel string
+	AnchorSink string
+	AnchorID   string
+}

--- a/sdk/verify.go
+++ b/sdk/verify.go
@@ -1,0 +1,62 @@
+package sdk
+
+import (
+	"io"
+
+	"github.com/ryan-wong-coder/trustdb/internal/sproof"
+	"github.com/ryan-wong-coder/trustdb/internal/verify"
+)
+
+func ReadSingleProofFile(path string) (SingleProof, error) {
+	return sproof.ReadFile(path)
+}
+
+func WriteSingleProofFile(path string, proof SingleProof) error {
+	return sproof.WriteFile(path, proof)
+}
+
+func VerifySingleProof(raw io.Reader, proof SingleProof, keys TrustedKeys, opts VerifyOptions) (VerifyResult, error) {
+	if err := sproof.Validate(proof); err != nil {
+		return VerifyResult{}, err
+	}
+	verifyOpts := []verify.Option{}
+	if proof.GlobalProof != nil {
+		verifyOpts = append(verifyOpts, verify.WithGlobalProof(*proof.GlobalProof))
+	}
+	if proof.AnchorResult != nil && !opts.SkipAnchor {
+		verifyOpts = append(verifyOpts, verify.WithAnchor(*proof.AnchorResult))
+	}
+	return verifyProofBundle(raw, proof.ProofBundle, keys, verifyOpts...)
+}
+
+func VerifyProofBundle(raw io.Reader, bundle ProofBundle, keys TrustedKeys) (VerifyResult, error) {
+	return verifyProofBundle(raw, bundle, keys)
+}
+
+func VerifyArtifacts(raw io.Reader, artifacts ProofArtifacts, keys TrustedKeys, opts VerifyOptions) (VerifyResult, error) {
+	verifyOpts := []verify.Option{}
+	if artifacts.GlobalProof != nil {
+		verifyOpts = append(verifyOpts, verify.WithGlobalProof(*artifacts.GlobalProof))
+	}
+	if artifacts.AnchorResult != nil && !opts.SkipAnchor {
+		verifyOpts = append(verifyOpts, verify.WithAnchor(*artifacts.AnchorResult))
+	}
+	return verifyProofBundle(raw, artifacts.Bundle, keys, verifyOpts...)
+}
+
+func verifyProofBundle(raw io.Reader, bundle ProofBundle, keys TrustedKeys, opts ...verify.Option) (VerifyResult, error) {
+	result, err := verify.ProofBundle(raw, bundle, verify.TrustedKeys{
+		ClientPublicKey: keys.ClientPublicKey,
+		ServerPublicKey: keys.ServerPublicKey,
+	}, opts...)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	return VerifyResult{
+		Valid:      result.Valid,
+		RecordID:   result.RecordID,
+		ProofLevel: result.ProofLevel,
+		AnchorSink: result.AnchorSink,
+		AnchorID:   result.AnchorID,
+	}, nil
+}


### PR DESCRIPTION
关联 #10

## 变更
- 新增公开包 `sdk`，外部可通过 `github.com/ryan-wong-coder/trustdb/sdk` 使用。
- SDK 支持构造/签名文件 claim、提交 signed claim、查询 record/proof/STH/anchor、导出 `.sproof`。
- SDK 支持本地验证 `.sproof`、L3 ProofBundle 和分步 proof artifacts。
- 新增可诊断 HTTP 错误类型 `sdk.Error`，提供 `IsNotFound` / `IsUnavailable` 辅助判断。
- README 增加 Go SDK 功能说明和最小示例。
- 新增 SDK 单测和外部包示例，确保公开别名/接口可被外部调用方编译使用。

## 验证
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `go test -p 1 -tags=integration ./...`
- `go test -tags=e2e ./...`
- `cd clients/desktop && go test ./...`
- `cd clients/desktop && go vet ./...`
- `cd clients/desktop && go test -race ./...`
- `cd clients/desktop/frontend && npm run build`
- `git diff --check`

## 边界
- 这轮先提供 SDK 能力，不迁移桌面客户端调用；桌面端替换为 SDK 建议作为后续独立 issue/PR。