### PR TITLE
客户端改用 Go SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![CI](https://github.com/ryan-wong-coder/trustdb/actions/workflows/ci.yml/badge.svg)
 
+[中文说明](README.zh-CN.md)
+
 ![TrustDB system architecture](assets/readme/system-architecture.png)
 
 TrustDB is a single-node verifiable evidence database. It turns local file claims into signed receipts, Merkle batch proofs, global transparency-log proofs, and optional external STH anchors.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,267 @@
+﻿# TrustDB
+
+![CI](https://github.com/ryan-wong-coder/trustdb/actions/workflows/ci.yml/badge.svg)
+
+[English README](README.md)
+
+![TrustDB 系统架构](assets/readme/system-architecture.png)
+
+TrustDB 是一个单机可验证存证数据库。它把本地文件声明转换为可离线验证的签名收据、批次 Merkle 证明、Global Transparency Log 证明，以及可选的外部 STH 锚定结果。
+
+当前 Go module：
+
+```text
+github.com/ryan-wong-coder/trustdb
+```
+
+许可证：AGPL-3.0-only，见 [LICENSE](LICENSE)。
+
+## 当前功能
+
+- 使用确定性 CBOR 编码 claim、receipt、proof bundle、global-log proof、STH、anchor result 和 `.sproof` 单文件证明。
+- 支持 Ed25519 客户端、服务端、registry 签名，以及 keygen、key inspect、registry register/revoke/list 等命令。
+- 支持文件 claim 创建：计算 SHA-256 内容哈希，可选复制到本地 object store。
+- WAL-backed ingest 路径，支持 `strict`、`group`、`batch` 三种 fsync 模式。
+- HTTP ingest server：有界队列、worker pool、健康检查、Prometheus metrics、优雅关闭。
+- Batch Merkle worker：生成 `ProofBundle` 和服务端 record index。
+- Global Transparency Log：提交 batch root 后追加全局日志，持久化 STH，并提供 inclusion/consistency proof。
+- L5 anchor pipeline：只锚定 `SignedTreeHead` / global root，不支持旧的 per-batch root 直锚。
+- Anchor sink：`off`、`noop`、本地文件、OpenTimestamps，并支持 OTS upgrade worker。
+- Proofstore：file 与 Pebble 两种后端；生产配置默认 Pebble。
+- 分页 record/root API，服务端列表路径使用 cursor/range 访问方式。
+- `.tdbackup` 备份创建、校验与可恢复 restore。
+- Go SDK：提供 claim 签名、服务端访问、证明导出、离线验证能力。
+- Wails + Vue 桌面客户端：支持初始化向导、本地身份、服务端配置、文件存证、记录管理、证明刷新、离线验证与 `.sproof` 导出。
+- 桌面客户端本地 records 使用 Pebble-backed index store，不再使用单个 JSON 文件承载全部记录。
+
+## 证明等级
+
+![TrustDB 证明等级](assets/readme/proof-levels.png)
+
+TrustDB 使用分层证明语义：
+
+| 等级 | 含义 | 主要产物 |
+| --- | --- | --- |
+| L1 | 客户端对包含文件哈希和元数据的 claim 签名。 | `SignedClaim` / `.tdclaim` |
+| L2 | 服务端校验 claim，并接受进入 WAL。 | `AcceptedReceipt` |
+| L3 | claim 被提交到 batch Merkle tree。 | `ProofBundle` / `.tdproof` |
+| L4 | batch root 已进入 Global Transparency Log，并能证明其包含在某个 STH 中。 | `GlobalLogProof` / `.tdgproof` |
+| L5 | 对应 STH/global root 已被外部 anchor sink 锚定。 | `STHAnchorResult` / `.tdanchor-result` |
+
+桌面客户端和交换场景推荐使用 `.sproof` 单文件证明。`.sproof` 可以同时包含 L3 `ProofBundle`、可选 L4 `GlobalLogProof`、可选 L5 `STHAnchorResult`。稳定 v1 格式见 [formats/SPROOF_V1.md](formats/SPROOF_V1.md)。
+
+## 架构设计
+
+当前实现是单机架构，主要路径如下：
+
+- 客户端路径：CLI 或桌面客户端计算文件哈希，签名 claim，通过 HTTP server 或本地 CLI 流程提交。
+- Ingest 路径：服务端校验签名和 key 状态，写入 WAL，返回 accepted receipt。
+- Batch 路径：已接受记录被 batch worker 聚合为 Merkle batch，并存储 proof bundle 与 record index。
+- Global Log 路径：已提交 batch root 被追加到 global transparency log，生成持久化 STH 与 global proof。
+- Anchor 路径：STH/global root 入队，由 anchor worker 按配置发布到 anchor sink。
+- Storage 路径：proof 数据落到 file 或 Pebble proofstore；生产配置默认 Pebble。
+- Backup 路径：proofstore 数据可导出为 `.tdbackup`，支持 verify 与带 checkpoint 的 restore。
+- Observability 路径：`/metrics` 暴露 ingest、batch、global log、anchor、WAL、backup、storage 等指标。
+
+## HTTP API
+
+已实现的 HTTP endpoint：
+
+| Endpoint | 用途 |
+| --- | --- |
+| `GET /healthz` | 健康检查。 |
+| `POST /v1/claims` | 提交签名 claim。 |
+| `GET /v1/records` | 分页 record 列表与搜索。 |
+| `GET /v1/records/{record_id}` | 读取 record index 详情。 |
+| `GET /v1/proofs/{record_id}` | 获取 L3 proof bundle。 |
+| `GET /v1/roots` | 列出 batch roots。 |
+| `GET /v1/roots/latest` | 获取最新 batch root。 |
+| `GET /v1/sth/latest` | 获取最新 SignedTreeHead。 |
+| `GET /v1/sth/{tree_size}` | 获取指定 tree size 的 STH。 |
+| `GET /v1/global-log/inclusion/{batch_id}` | 获取 batch 的 global-log inclusion proof。 |
+| `GET /v1/global-log/consistency?from=&to=` | 获取 global-log consistency proof。 |
+| `GET /v1/anchors/sth/{tree_size}` | 获取 STH anchor 状态或结果。 |
+| `GET /metrics` | Prometheus metrics。 |
+
+## 快速向导
+
+生成客户端和服务端密钥：
+
+```powershell
+go run ./cmd/trustdb keygen --out .trustdb-dev --prefix client
+go run ./cmd/trustdb keygen --out .trustdb-dev --prefix server
+```
+
+用直接信任客户端公钥的方式启动本地开发服务：
+
+```powershell
+go run ./cmd/trustdb serve `
+  --config configs/development.yaml `
+  --server-private-key .trustdb-dev/server.key `
+  --client-public-key .trustdb-dev/client.pub `
+  --listen 127.0.0.1:8080
+```
+
+创建并签名一个文件 claim：
+
+```powershell
+go run ./cmd/trustdb claim-file `
+  --file .\example.txt `
+  --private-key .trustdb-dev/client.key `
+  --tenant default `
+  --client local-client `
+  --key-id client-key `
+  --out .trustdb-dev/example.tdclaim
+```
+
+把签名 claim 本地提交为 proof bundle：
+
+```powershell
+go run ./cmd/trustdb commit `
+  --claim .trustdb-dev/example.tdclaim `
+  --server-private-key .trustdb-dev/server.key `
+  --client-public-key .trustdb-dev/client.pub `
+  --out .trustdb-dev/example.tdproof
+```
+
+验证本地文件和 proof bundle：
+
+```powershell
+go run ./cmd/trustdb verify `
+  --file .\example.txt `
+  --proof .trustdb-dev/example.tdproof `
+  --server-public-key .trustdb-dev/server.pub `
+  --client-public-key .trustdb-dev/client.pub
+```
+
+使用推荐的 `.sproof` 单文件证明验证：
+
+```powershell
+go run ./cmd/trustdb verify `
+  --file .\example.txt `
+  --sproof .trustdb-dev/example.sproof `
+  --server-public-key .trustdb-dev/server.pub `
+  --client-public-key .trustdb-dev/client.pub
+```
+
+查看 Global Log 数据：
+
+```powershell
+go run ./cmd/trustdb global-log sth latest --metastore file --metastore-path .trustdb-dev/proofs
+go run ./cmd/trustdb global-log proof inclusion --batch-id batch-000001 --metastore file --metastore-path .trustdb-dev/proofs
+```
+
+创建并校验便携备份：
+
+```powershell
+go run ./cmd/trustdb backup create `
+  --metastore file `
+  --metastore-path .trustdb-dev/proofs `
+  --out .trustdb-dev/trustdb.tdbackup
+
+go run ./cmd/trustdb backup verify --file .trustdb-dev/trustdb.tdbackup
+```
+
+## 配置
+
+仓库内包含两个示例配置：
+
+| 文件 | 用途 |
+| --- | --- |
+| `configs/development.yaml` | 本地开发与演示。使用 file proofstore 和 `noop` anchor sink。 |
+| `configs/production.yaml` | 单机生产配置。使用 Pebble proofstore、directory WAL、group fsync、global log 和 OTS anchor sink。 |
+
+主要配置组：
+
+| 配置组 | 作用 |
+| --- | --- |
+| `paths` | 数据、key registry、WAL、object、proof 目录。 |
+| `metastore` / `metastore_path` | Proofstore 后端：`file` 或 `pebble`。 |
+| `wal` | Fsync 策略与 group commit interval。 |
+| `server` | 监听地址、队列大小、worker 数量和 timeout。 |
+| `batch` | Batch 队列、最大记录数、最大延迟。 |
+| `global_log` | 是否启用 global transparency log。 |
+| `anchor` | L5 anchor scope、sink、max delay、OTS calendars、OTS upgrader。 |
+| `history` | Global-log tile size 与 hot window。 |
+| `backup` | 备份压缩方式。 |
+| `log` | 结构化日志、轮转与异步日志。 |
+| `keys` | 客户端、服务端、registry key 文件路径。 |
+
+大多数配置可以通过 `TRUSTDB_*` 环境变量或命令行 flag 覆盖。运行 `go run ./cmd/trustdb serve --help` 查看当前已实现的服务端参数。
+
+## 桌面客户端
+
+桌面客户端位于 `clients/desktop`，使用 Wails + Vue。当前支持：
+
+- 初始化向导：本地身份生成/导入、服务端地址与公钥配置；
+- 向 TrustDB HTTP server 发起文件存证；
+- 本地 record 分页列表、搜索、筛选、详情、删除和 proof 状态刷新；
+- `.sproof` 作为主要导出格式；
+- 高级导出 `.tdproof`、`.tdgproof`、`.tdanchor-result`；
+- 本地离线验证，可选 L4/L5 artifacts；
+- 本地 records 持久化到 Pebble-backed index store。
+
+桌面端常用检查：
+
+```powershell
+cd clients/desktop
+go test ./...
+cd frontend
+npm run build
+```
+
+## Go SDK
+
+Go SDK 位于 `sdk`，导入路径：
+
+```go
+import "github.com/ryan-wong-coder/trustdb/sdk"
+```
+
+当前 SDK 能力：
+
+- 构造并签名文件 claim；
+- 提交 signed claim 到 `POST /v1/claims`；
+- 查询 records、proof bundles、STH、GlobalLogProof、STH anchor state；
+- 导出推荐的 `.sproof` 单文件证明；
+- 本地验证 `.sproof` 或拆分 proof artifacts；
+- 读取 health、batch roots 和 Prometheus metrics，供客户端复用服务端访问逻辑。
+
+最小示例：
+
+```go
+client, err := sdk.NewClient("http://127.0.0.1:8080")
+if err != nil {
+    return err
+}
+proof, err := client.ExportSingleProof(ctx, recordID)
+if err != nil {
+    return err
+}
+return sdk.WriteSingleProofFile("example.sproof", proof)
+```
+
+## 开发检查
+
+PR 会运行 `.github/workflows/ci.yml` 中的 GitHub Actions，包括仓库卫生检查、后端 unit/race/integration/e2e tests、桌面端 Go tests 和桌面前端 build。
+
+常用检查：
+
+```powershell
+go test ./...
+go test -tags=integration ./...
+go test -tags=e2e ./...
+go test -race ./...
+cd clients/desktop; go test ./...
+cd clients/desktop/frontend; npm run build
+```
+
+当前测试覆盖 deterministic CBOR、claims、WAL、batch proofs、global log proofs、anchors、backup/restore、HTTP API、桌面端本地存储和验证路径。
+
+## 贡献方式
+
+TrustDB 使用 Issue-first 开发流程。开始代码、文档、重构或运维工作前，需要创建或关联 GitHub Issue，并写清范围、验收标准和测试计划。
+
+Bug、功能和工程任务请使用仓库 Issue 模板。PR 应使用仓库 PR 模板，并引用关联 Issue。
+
+完整贡献流程、分支约定、commit/PR 要求、CI 质量门、测试矩阵、文档规则与安全注意事项见 [CONTRIBUTING.md](CONTRIBUTING.md)。

--- a/clients/desktop/client.go
+++ b/clients/desktop/client.go
@@ -1,101 +1,31 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"net/http"
-	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/ryan-wong-coder/trustdb/internal/model"
 	"github.com/ryan-wong-coder/trustdb/internal/prooflevel"
+	"github.com/ryan-wong-coder/trustdb/sdk"
 )
 
-// httpTimeout bounds each request against the server. Submit + proof
-// queries are small (<1MB) so a short timeout gives a clear failure
-// mode when the server is down or unreachable.
-const httpTimeout = 15 * time.Second
-
 type httpClient struct {
-	base  string
-	inner *http.Client
+	sdk *sdk.Client
 }
 
 func newHTTPClient(base string) (*httpClient, error) {
-	trimmed := strings.TrimSpace(base)
-	if trimmed == "" {
-		return nil, fmt.Errorf("server url is empty")
-	}
-	u, err := url.Parse(trimmed)
+	client, err := sdk.NewClient(base)
 	if err != nil {
-		return nil, fmt.Errorf("parse server url: %w", err)
+		return nil, err
 	}
-	if u.Scheme == "" || u.Host == "" {
-		return nil, fmt.Errorf("server url must include scheme and host: %s", trimmed)
-	}
-	return &httpClient{base: strings.TrimRight(trimmed, "/"), inner: &http.Client{Timeout: httpTimeout}}, nil
+	return &httpClient{sdk: client}, nil
 }
 
-func (c *httpClient) url(p string, parts ...string) string {
-	// Manual assembly is safer than a single url.Parse here because
-	// record ids contain characters (e.g. lower-case base32) that we
-	// want percent-encoded while the static prefix stays untouched.
-	out := c.base + p
-	for _, part := range parts {
-		out += url.PathEscape(part)
-	}
-	return out
-}
-
-type ServerError struct {
-	StatusCode int
-	Code       string `json:"code"`
-	Message    string `json:"message"`
-}
-
-func (e *ServerError) Error() string {
-	if e.Code != "" {
-		return fmt.Sprintf("%s: %s", e.Code, e.Message)
-	}
-	return fmt.Sprintf("http %d: %s", e.StatusCode, e.Message)
-}
-
-// decodeError tries to parse the server's structured error envelope
-// (trusterr.Code + message) and falls back to the raw body if the
-// response isn't JSON, so the UI always surfaces *something*
-// actionable instead of a blank "request failed".
-func decodeError(resp *http.Response) error {
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 16<<10))
-	var se ServerError
-	if err := json.Unmarshal(body, &se); err == nil && (se.Code != "" || se.Message != "") {
-		se.StatusCode = resp.StatusCode
-		return &se
-	}
-	return &ServerError{StatusCode: resp.StatusCode, Message: strings.TrimSpace(string(body))}
-}
-
-func (c *httpClient) getJSON(ctx context.Context, endpoint string, dst any) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return err
-	}
-	resp, err := c.inner.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return decodeError(resp)
-	}
-	return json.NewDecoder(resp.Body).Decode(dst)
-}
+type ServerError = sdk.Error
 
 type HealthStatus struct {
 	OK         bool   `json:"ok"`
@@ -106,92 +36,30 @@ type HealthStatus struct {
 }
 
 func (c *httpClient) health(ctx context.Context) HealthStatus {
-	start := time.Now()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.base+"/healthz", nil)
-	if err != nil {
-		return HealthStatus{ServerURL: c.base, Error: err.Error()}
+	status := c.sdk.CheckHealth(ctx)
+	return HealthStatus{
+		OK:         status.OK,
+		ServerURL:  status.ServerURL,
+		RTTMillis:  status.RTTMillis,
+		Error:      status.Error,
+		StatusCode: status.StatusCode,
 	}
-	resp, err := c.inner.Do(req)
-	rtt := time.Since(start).Milliseconds()
-	if err != nil {
-		return HealthStatus{ServerURL: c.base, Error: err.Error(), RTTMillis: rtt}
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return HealthStatus{ServerURL: c.base, Error: "unhealthy", StatusCode: resp.StatusCode, RTTMillis: rtt}
-	}
-	return HealthStatus{OK: true, ServerURL: c.base, RTTMillis: rtt}
 }
 
-// submitClaimResult mirrors the server's submitClaimResponse so the
-// UI can inspect batch_enqueued / idempotent flags without making a
-// second call.
-type submitClaimResult struct {
-	RecordID        string                `json:"record_id"`
-	Status          string                `json:"status"`
-	ProofLevel      string                `json:"proof_level"`
-	Idempotent      bool                  `json:"idempotent"`
-	BatchEnqueued   bool                  `json:"batch_enqueued"`
-	BatchError      string                `json:"batch_error,omitempty"`
-	ServerRecord    model.ServerRecord    `json:"server_record"`
-	AcceptedReceipt model.AcceptedReceipt `json:"accepted_receipt"`
-}
+// submitClaimResult mirrors the server's submit response so the UI can inspect
+// batch_enqueued / idempotent flags without making a second call.
+type submitClaimResult = sdk.SubmitResult
 
-func (c *httpClient) submitClaimCBOR(ctx context.Context, body []byte) (submitClaimResult, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/v1/claims", bytes.NewReader(body))
-	if err != nil {
-		return submitClaimResult{}, err
-	}
-	req.Header.Set("Content-Type", "application/cbor")
-	resp, err := c.inner.Do(req)
-	if err != nil {
-		return submitClaimResult{}, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
-		return submitClaimResult{}, decodeError(resp)
-	}
-	var out submitClaimResult
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return submitClaimResult{}, fmt.Errorf("decode submit response: %w", err)
-	}
-	return out, nil
-}
-
-type proofEnvelope struct {
-	RecordID    string            `json:"record_id"`
-	ProofLevel  string            `json:"proof_level"`
-	ProofBundle model.ProofBundle `json:"proof_bundle"`
-}
-
-type recordsEnvelope struct {
-	Records    []model.RecordIndex `json:"records"`
-	Limit      int                 `json:"limit"`
-	Direction  string              `json:"direction"`
-	NextCursor string              `json:"next_cursor,omitempty"`
+func (c *httpClient) submitSignedClaim(ctx context.Context, signed model.SignedClaim) (submitClaimResult, error) {
+	return c.sdk.SubmitSignedClaim(ctx, signed)
 }
 
 func (c *httpClient) getProof(ctx context.Context, recordID string) (model.ProofBundle, error) {
-	endpoint := c.url("/v1/proofs/", recordID)
-	var env proofEnvelope
-	if err := c.getJSON(ctx, endpoint, &env); err != nil {
-		return model.ProofBundle{}, err
-	}
-	if env.ProofBundle.RecordID == "" {
-		return model.ProofBundle{}, fmt.Errorf("server returned empty proof bundle")
-	}
-	return env.ProofBundle, nil
+	return c.sdk.GetProofBundle(ctx, recordID)
 }
 
 func (c *httpClient) getRecordIndex(ctx context.Context, recordID string) (model.RecordIndex, error) {
-	var idx model.RecordIndex
-	if err := c.getJSON(ctx, c.url("/v1/records/", recordID), &idx); err != nil {
-		return model.RecordIndex{}, err
-	}
-	if idx.RecordID == "" {
-		return model.RecordIndex{}, fmt.Errorf("server returned empty record index")
-	}
-	return idx, nil
+	return c.sdk.GetRecord(ctx, recordID)
 }
 
 func (c *httpClient) listRecordIndexes(ctx context.Context, opts RecordPageOptions) (RecordPage, error) {
@@ -204,7 +72,7 @@ func (c *httpClient) listRecordIndexes(ctx context.Context, opts RecordPageOptio
 	}
 	direction := strings.TrimSpace(opts.Direction)
 	if direction == "" {
-		direction = "desc"
+		direction = sdk.RecordListDirectionDesc
 	}
 
 	query := strings.TrimSpace(opts.Query)
@@ -238,38 +106,25 @@ func (c *httpClient) listRecordIndexes(ctx context.Context, opts RecordPageOptio
 		}
 	}
 
-	values := url.Values{}
-	values.Set("limit", strconv.Itoa(limit))
-	values.Set("direction", direction)
-	if opts.Cursor != "" {
-		values.Set("cursor", opts.Cursor)
-	}
-	if opts.BatchID != "" {
-		values.Set("batch_id", opts.BatchID)
-	}
-	if opts.TenantID != "" {
-		values.Set("tenant_id", opts.TenantID)
-	}
-	if opts.ClientID != "" {
-		values.Set("client_id", opts.ClientID)
-	}
-	if contentHash != "" {
-		values.Set("content_hash", contentHash)
-	}
-	if query != "" {
-		values.Set("q", query)
-	}
-	endpoint := c.base + "/v1/records?" + values.Encode()
-	var env recordsEnvelope
-	if err := c.getJSON(ctx, endpoint, &env); err != nil {
+	page, err := c.sdk.ListRecords(ctx, sdk.ListRecordsOptions{
+		Limit:          limit,
+		Direction:      direction,
+		Cursor:         opts.Cursor,
+		BatchID:        opts.BatchID,
+		TenantID:       opts.TenantID,
+		ClientID:       opts.ClientID,
+		Query:          query,
+		ContentHashHex: contentHash,
+	})
+	if err != nil {
 		return RecordPage{}, err
 	}
-	items := make([]LocalRecord, 0, len(env.Records))
-	for _, idx := range env.Records {
+	items := make([]LocalRecord, 0, len(page.Records))
+	for _, idx := range page.Records {
 		items = append(items, localRecordFromIndex(idx))
 	}
 	total := opts.Offset + len(items)
-	if env.NextCursor != "" {
+	if page.NextCursor != "" {
 		total++
 	}
 	return RecordPage{
@@ -277,10 +132,10 @@ func (c *httpClient) listRecordIndexes(ctx context.Context, opts RecordPageOptio
 		Total:      total,
 		Limit:      limit,
 		Offset:     opts.Offset,
-		HasMore:    env.NextCursor != "",
-		NextCursor: env.NextCursor,
+		HasMore:    page.NextCursor != "",
+		NextCursor: page.NextCursor,
 		Source:     "server",
-		TotalExact: env.NextCursor == "",
+		TotalExact: page.NextCursor == "",
 	}, nil
 }
 
@@ -369,79 +224,32 @@ type anchorEnvelope struct {
 }
 
 func (c *httpClient) getGlobalProof(ctx context.Context, batchID string) (model.GlobalLogProof, error) {
-	endpoint := c.url("/v1/global-log/inclusion/", batchID)
-	var proof model.GlobalLogProof
-	if err := c.getJSON(ctx, endpoint, &proof); err != nil {
-		return model.GlobalLogProof{}, err
-	}
-	return proof, nil
+	return c.sdk.GetGlobalProof(ctx, batchID)
 }
 
 func (c *httpClient) getAnchor(ctx context.Context, treeSize uint64) (anchorEnvelope, error) {
-	endpoint := c.url("/v1/anchors/sth/", fmt.Sprintf("%d", treeSize))
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	status, err := c.sdk.GetAnchor(ctx, treeSize)
 	if err != nil {
+		if sdk.IsUnavailable(err) {
+			return anchorEnvelope{TreeSize: treeSize, Status: "unavailable"}, nil
+		}
 		return anchorEnvelope{}, err
 	}
-	resp, err := c.inner.Do(req)
-	if err != nil {
-		return anchorEnvelope{}, err
-	}
-	defer resp.Body.Close()
-	// 404 / 412 are "no anchor yet" — legitimate states, not errors.
-	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusPreconditionFailed {
-		return anchorEnvelope{TreeSize: treeSize, Status: "unavailable"}, nil
-	}
-	if resp.StatusCode != http.StatusOK {
-		return anchorEnvelope{}, decodeError(resp)
-	}
-	var env anchorEnvelope
-	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
-		return anchorEnvelope{}, fmt.Errorf("decode anchor response: %w", err)
-	}
-	return env, nil
-}
-
-type rootsEnvelope struct {
-	Roots []model.BatchRoot `json:"roots"`
+	return anchorEnvelope{TreeSize: status.TreeSize, Status: status.Status, Result: status.Result}, nil
 }
 
 func (c *httpClient) listRoots(ctx context.Context, limit int) ([]model.BatchRoot, error) {
-	if limit <= 0 {
-		limit = 100
-	}
-	endpoint := c.base + "/v1/roots?limit=" + strconv.Itoa(limit)
-	var env rootsEnvelope
-	if err := c.getJSON(ctx, endpoint, &env); err != nil {
-		return nil, err
-	}
-	return env.Roots, nil
+	return c.sdk.ListRoots(ctx, limit)
 }
 
 func (c *httpClient) latestRoot(ctx context.Context) (model.BatchRoot, error) {
-	var root model.BatchRoot
-	if err := c.getJSON(ctx, c.base+"/v1/roots/latest", &root); err != nil {
-		return model.BatchRoot{}, err
-	}
-	return root, nil
+	return c.sdk.LatestRoot(ctx)
 }
 
 func (c *httpClient) metricsRaw(ctx context.Context) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.base+"/metrics", nil)
-	if err != nil {
-		return "", err
-	}
-	resp, err := c.inner.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", decodeError(resp)
-	}
-	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if err != nil {
-		return "", err
-	}
-	return string(raw), nil
+	return c.sdk.MetricsRaw(ctx)
+}
+
+func (c *httpClient) exportSingleProof(ctx context.Context, recordID string) (model.SingleProof, error) {
+	return c.sdk.ExportSingleProof(ctx, recordID)
 }

--- a/clients/desktop/client_test.go
+++ b/clients/desktop/client_test.go
@@ -11,6 +11,13 @@ import (
 	"github.com/ryan-wong-coder/trustdb/internal/model"
 )
 
+type recordPageResponse struct {
+	Records    []model.RecordIndex `json:"records"`
+	Limit      int                 `json:"limit"`
+	Direction  string              `json:"direction"`
+	NextCursor string              `json:"next_cursor,omitempty"`
+}
+
 func TestHTTPClientListRecordIndexesMapsServerPage(t *testing.T) {
 	t.Parallel()
 
@@ -22,7 +29,7 @@ func TestHTTPClientListRecordIndexesMapsServerPage(t *testing.T) {
 		if q.Get("limit") != "2" || q.Get("cursor") != "cur-1" || q.Get("batch_id") != "batch-1" || q.Get("direction") != "desc" {
 			t.Fatalf("query = %s", r.URL.RawQuery)
 		}
-		_ = json.NewEncoder(w).Encode(recordsEnvelope{
+		_ = json.NewEncoder(w).Encode(recordPageResponse{
 			Records: []model.RecordIndex{{
 				SchemaVersion:      model.SchemaRecordIndex,
 				RecordID:           "tr1record",
@@ -122,7 +129,7 @@ func TestHTTPClientListRecordIndexesSendsServerSearchFilters(t *testing.T) {
 		default:
 			t.Fatalf("unexpected query = %s", r.URL.RawQuery)
 		}
-		_ = json.NewEncoder(w).Encode(recordsEnvelope{Limit: 50, Direction: "desc"})
+		_ = json.NewEncoder(w).Encode(recordPageResponse{Limit: 50, Direction: "desc"})
 	}))
 	defer srv.Close()
 

--- a/clients/desktop/submit.go
+++ b/clients/desktop/submit.go
@@ -34,7 +34,7 @@ type SubmitResult struct {
 	BatchError  string      `json:"batch_error,omitempty"`
 }
 
-// SubmitFile hashes, signs, CBOR-encodes and POSTs one file to the
+// SubmitFile hashes, signs and submits one file through the shared Go SDK to the
 // configured TrustDB server. On success we persist a LocalRecord so
 // the Records page can resume tracking (L2→L3→L5) across restarts.
 // Any error leaves the store untouched — a half-submitted attestation
@@ -83,16 +83,12 @@ func (a *App) SubmitFile(req SubmitRequest) (*SubmitResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	body, err := marshalClaim(signed)
-	if err != nil {
-		return nil, fmt.Errorf("encode claim: %w", err)
-	}
 
 	c, err := a.httpClient()
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.submitClaimCBOR(a.ensureCtx(), body)
+	resp, err := c.submitSignedClaim(a.ensureCtx(), signed)
 	if err != nil {
 		return nil, err
 	}
@@ -304,44 +300,12 @@ func (a *App) buildSingleProof(recordID string) (model.SingleProof, error) {
 	if err != nil {
 		return model.SingleProof{}, err
 	}
-	ctx := a.ensureCtx()
-	bundle, err := c.getProof(ctx, recordID)
+	proof, err := c.exportSingleProof(a.ensureCtx(), recordID)
 	if err != nil {
 		return model.SingleProof{}, err
 	}
-	opts := sproof.Options{ExportedAtUnixN: time.Now().UTC().UnixNano()}
-
-	globalProof, err := c.getGlobalProof(ctx, bundle.CommittedReceipt.BatchID)
-	if err != nil {
-		if proofArtifactUnavailable(err) {
-			a.mergeExportedProofState(recordID, bundle, nil, nil)
-			return sproof.New(bundle, opts)
-		}
-		return model.SingleProof{}, fmt.Errorf("fetch global proof: %w", err)
-	}
-	opts.GlobalProof = &globalProof
-
-	anchor, err := c.getAnchor(ctx, globalProof.STH.TreeSize)
-	if err != nil {
-		return model.SingleProof{}, fmt.Errorf("fetch STH anchor: %w", err)
-	}
-	if anchor.Result != nil {
-		opts.AnchorResult = anchor.Result
-	}
-	out, err := sproof.New(bundle, opts)
-	if err != nil {
-		return model.SingleProof{}, err
-	}
-	a.mergeExportedProofState(recordID, bundle, out.GlobalProof, out.AnchorResult)
-	return out, nil
-}
-
-func proofArtifactUnavailable(err error) bool {
-	var se *ServerError
-	if errors.As(err, &se) {
-		return se.StatusCode == 404 || se.StatusCode == 412
-	}
-	return false
+	a.mergeExportedProofState(recordID, proof.ProofBundle, proof.GlobalProof, proof.AnchorResult)
+	return proof, nil
 }
 
 func (a *App) mergeExportedProofState(recordID string, bundle model.ProofBundle, global *model.GlobalLogProof, anchor *model.STHAnchorResult) {

--- a/clients/desktop/verify.go
+++ b/clients/desktop/verify.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ryan-wong-coder/trustdb/internal/cborx"
 	"github.com/ryan-wong-coder/trustdb/internal/model"
 	"github.com/ryan-wong-coder/trustdb/internal/sproof"
-	"github.com/ryan-wong-coder/trustdb/internal/verify"
+	"github.com/ryan-wong-coder/trustdb/sdk"
 )
 
 // VerifyRequest covers both verify modes the UI offers:
@@ -59,8 +59,8 @@ type VerifyResponse struct {
 
 // VerifyProof is the sole verify entry point exposed to the frontend.
 // It dispatches to local-file or remote-http input acquisition, then
-// calls into the shared verify.ProofBundle routine used by the CLI,
-// so the desktop and the CLI can never diverge on validity rules.
+// calls into the shared Go SDK verification routine, so desktop callers use the
+// same verification surface as external applications.
 func (a *App) VerifyProof(req VerifyRequest) (*VerifyResponse, error) {
 	if _, err := a.requireStore(); err != nil {
 		return nil, err
@@ -153,18 +153,14 @@ func (a *App) VerifyProof(req VerifyRequest) (*VerifyResponse, error) {
 	}
 	defer f.Close()
 
-	opts := []verify.Option{}
-	if globalProof != nil {
-		opts = append(opts, verify.WithGlobalProof(*globalProof))
-	}
-	if anchor != nil {
-		opts = append(opts, verify.WithAnchor(*anchor))
-	}
-
-	res, err := verify.ProofBundle(f, bundle, verify.TrustedKeys{
+	res, err := sdk.VerifyArtifacts(f, sdk.ProofArtifacts{
+		Bundle:       bundle,
+		GlobalProof:  globalProof,
+		AnchorResult: anchor,
+	}, sdk.TrustedKeys{
 		ClientPublicKey: clientPub,
 		ServerPublicKey: serverPub,
-	}, opts...)
+	}, sdk.VerifyOptions{SkipAnchor: req.SkipAnchor})
 	if err != nil {
 		return &VerifyResponse{
 			Valid:        false,

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -67,17 +67,37 @@ func NewClient(baseURL string, opts ...Option) (*Client, error) {
 	return c, nil
 }
 
+func (c *Client) BaseURL() string {
+	return c.baseURL
+}
+
 func (c *Client) Health(ctx context.Context) error {
+	status := c.CheckHealth(ctx)
+	if status.OK {
+		return nil
+	}
+	return &Error{Op: "health", URL: c.baseURL + "/healthz", StatusCode: status.StatusCode, Message: status.Error}
+}
+
+func (c *Client) CheckHealth(ctx context.Context) HealthStatus {
+	start := time.Now()
 	var out struct {
 		OK bool `json:"ok"`
 	}
-	if err := c.getJSON(ctx, "/healthz", nil, &out); err != nil {
-		return err
+	err := c.getJSON(ctx, "/healthz", nil, &out)
+	rtt := time.Since(start).Milliseconds()
+	if err != nil {
+		var sdkErr *Error
+		statusCode := 0
+		if errors.As(err, &sdkErr) {
+			statusCode = sdkErr.StatusCode
+		}
+		return HealthStatus{ServerURL: c.baseURL, RTTMillis: rtt, StatusCode: statusCode, Error: err.Error()}
 	}
 	if !out.OK {
-		return &Error{Op: "health", Message: "server returned ok=false"}
+		return HealthStatus{ServerURL: c.baseURL, RTTMillis: rtt, Error: "server returned ok=false"}
 	}
-	return nil
+	return HealthStatus{OK: true, ServerURL: c.baseURL, RTTMillis: rtt}
 }
 
 func (c *Client) SubmitFile(ctx context.Context, raw io.Reader, id Identity, opts FileClaimOptions) (SubmitResult, error) {
@@ -164,6 +184,29 @@ func (c *Client) ListRecords(ctx context.Context, opts ListRecordsOptions) (Reco
 	}, nil
 }
 
+func (c *Client) ListRoots(ctx context.Context, limit int) ([]BatchRoot, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	values := url.Values{}
+	values.Set("limit", strconv.Itoa(limit))
+	var env rootsEnvelope
+	if err := c.getJSON(ctx, "/v1/roots", values, &env); err != nil {
+		return nil, err
+	}
+	roots := make([]BatchRoot, 0, len(env.Roots))
+	roots = append(roots, env.Roots...)
+	return roots, nil
+}
+
+func (c *Client) LatestRoot(ctx context.Context) (BatchRoot, error) {
+	var root model.BatchRoot
+	if err := c.getJSON(ctx, "/v1/roots/latest", nil, &root); err != nil {
+		return BatchRoot{}, err
+	}
+	return root, nil
+}
+
 func (c *Client) GetProofBundle(ctx context.Context, recordID string) (ProofBundle, error) {
 	var env proofEnvelope
 	if err := c.getJSON(ctx, "/v1/proofs/"+url.PathEscape(recordID), nil, &env); err != nil {
@@ -244,6 +287,14 @@ func (c *Client) WriteSingleProofFile(ctx context.Context, recordID, path string
 	return sproof.WriteFile(path, proof)
 }
 
+func (c *Client) MetricsRaw(ctx context.Context) (string, error) {
+	raw, err := c.doRaw(ctx, http.MethodGet, "/metrics", nil, nil, "", 1<<20)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
 func (c *Client) getJSON(ctx context.Context, path string, query url.Values, dst any) error {
 	return c.doJSON(ctx, http.MethodGet, path, query, nil, "", dst)
 }
@@ -286,6 +337,47 @@ func (c *Client) doJSON(
 		return &Error{Op: method, URL: endpoint, Err: fmt.Errorf("decode json: %w", err)}
 	}
 	return nil
+}
+
+func (c *Client) doRaw(
+	ctx context.Context,
+	method string,
+	path string,
+	query url.Values,
+	body io.Reader,
+	contentType string,
+	limit int64,
+) ([]byte, error) {
+	endpoint := c.baseURL + path
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return nil, &Error{Op: method, URL: endpoint, Err: err}
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, &Error{Op: method, URL: endpoint, Err: err}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, decodeHTTPError(method, endpoint, resp)
+	}
+	if limit <= 0 {
+		limit = 1 << 20
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, limit))
+	if err != nil {
+		return nil, &Error{Op: method, URL: endpoint, Err: err}
+	}
+	return raw, nil
 }
 
 func decodeHTTPError(method, endpoint string, resp *http.Response) error {
@@ -339,6 +431,10 @@ type recordsEnvelope struct {
 	Limit      int           `json:"limit"`
 	Direction  string        `json:"direction"`
 	NextCursor string        `json:"next_cursor,omitempty"`
+}
+
+type rootsEnvelope struct {
+	Roots []BatchRoot `json:"roots"`
 }
 
 type anchorEnvelope struct {

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -120,6 +120,67 @@ func TestClientListRecordsEncodesQuery(t *testing.T) {
 	}
 }
 
+func TestClientOperationalEndpoints(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			writeJSONForTest(t, w, http.StatusOK, map[string]bool{"ok": true})
+		case "/v1/roots":
+			if r.URL.Query().Get("limit") != "7" {
+				t.Fatalf("roots query = %s", r.URL.RawQuery)
+			}
+			writeJSONForTest(t, w, http.StatusOK, rootsEnvelope{Roots: []BatchRoot{{
+				SchemaVersion: model.SchemaBatchRoot,
+				BatchID:       "batch-1",
+				TreeSize:      1,
+			}}})
+		case "/v1/roots/latest":
+			writeJSONForTest(t, w, http.StatusOK, BatchRoot{
+				SchemaVersion: model.SchemaBatchRoot,
+				BatchID:       "batch-latest",
+				TreeSize:      2,
+			})
+		case "/metrics":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("trustdb_ingest_total 1\n"))
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if status := client.CheckHealth(context.Background()); !status.OK || status.ServerURL != server.URL {
+		t.Fatalf("health status = %+v", status)
+	}
+	roots, err := client.ListRoots(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("ListRoots: %v", err)
+	}
+	if len(roots) != 1 || roots[0].BatchID != "batch-1" {
+		t.Fatalf("roots = %+v", roots)
+	}
+	latest, err := client.LatestRoot(context.Background())
+	if err != nil {
+		t.Fatalf("LatestRoot: %v", err)
+	}
+	if latest.BatchID != "batch-latest" {
+		t.Fatalf("latest = %+v", latest)
+	}
+	metrics, err := client.MetricsRaw(context.Background())
+	if err != nil {
+		t.Fatalf("MetricsRaw: %v", err)
+	}
+	if !strings.Contains(metrics, "trustdb_ingest_total") {
+		t.Fatalf("metrics = %q", metrics)
+	}
+}
+
 func TestClientExportSingleProofFallsBackToL3WhenGlobalProofUnavailable(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/types.go
+++ b/sdk/types.go
@@ -84,6 +84,14 @@ type RecordPage struct {
 	NextCursor string
 }
 
+type HealthStatus struct {
+	OK         bool
+	ServerURL  string
+	RTTMillis  int64
+	Error      string
+	StatusCode int
+}
+
 type AnchorStatus struct {
 	TreeSize uint64
 	Status   string


### PR DESCRIPTION
## 关联
- Closes #11

## 变更
- 扩展 Go SDK：增加健康检查状态、batch roots、latest root、metrics raw 读取能力，并补充 SDK 测试。
- 桌面客户端服务端访问改为复用 Go SDK：提交 claim、record 列表/详情、proof/global proof/anchor、roots、metrics、`.sproof` 导出都走 SDK 适配层。
- 桌面端验证改用 SDK verification surface，减少桌面端直接依赖内部 verify 细节。
- 新增 `README.zh-CN.md`，英文 README 增加中文版入口。

## 验证
- `go test ./sdk`
- `go test ./clients/desktop`
- `go test ./...`
- `go vet ./...`
- `cd clients/desktop && go vet ./...`
- `go test -race ./...`
- `go test -p 1 -tags=integration ./...`
- `go test -tags=e2e ./...`
- `cd clients/desktop && go test -race ./...`
- `cd clients/desktop/frontend && npm run build`
- `git diff --check`
- `cd clients/desktop && wails build`