### PR TITLE
桌面客户端支持 HTTP/gRPC transport 切换

### DIFF
--- a/clients/desktop/app.go
+++ b/clients/desktop/app.go
@@ -250,6 +250,9 @@ func (a *App) SaveSettings(s Settings) error {
 	if err != nil {
 		return err
 	}
+	if !validServerTransport(s.ServerTransport) {
+		return fmt.Errorf("unsupported server transport: %s", s.ServerTransport)
+	}
 	if s.ServerPubKeyB64 != "" {
 		raw, err := decodeKeyField(s.ServerPubKeyB64)
 		if err != nil {
@@ -505,10 +508,11 @@ func (a *App) ListRecordsPage(opts RecordPageOptions) RecordPage {
 }
 
 func (a *App) ListRemoteRecordsPage(opts RecordPageOptions) (RecordPage, error) {
-	c, err := a.httpClient()
+	c, err := a.serverClient()
 	if err != nil {
 		return RecordPage{}, err
 	}
+	defer c.close()
 	return c.listRecordIndexes(a.ensureCtx(), opts)
 }
 
@@ -523,36 +527,40 @@ func (a *App) DeleteRecord(recordID string) error {
 // --- Server health & roots -----------------------------------------
 
 func (a *App) ServerHealth() HealthStatus {
-	c, err := a.httpClient()
+	c, err := a.serverClient()
 	if err != nil {
 		return HealthStatus{Error: err.Error()}
 	}
+	defer c.close()
 	return c.health(a.ensureCtx())
 }
 
 func (a *App) LatestRoot() (model.BatchRoot, error) {
-	c, err := a.httpClient()
+	c, err := a.serverClient()
 	if err != nil {
 		return model.BatchRoot{}, err
 	}
+	defer c.close()
 	return c.latestRoot(a.ensureCtx())
 }
 
 func (a *App) ListRoots(limit int) ([]model.BatchRoot, error) {
-	c, err := a.httpClient()
+	c, err := a.serverClient()
 	if err != nil {
 		return nil, err
 	}
+	defer c.close()
 	return c.listRoots(a.ensureCtx(), limit)
 }
 
 // --- Metrics --------------------------------------------------------
 
 func (a *App) ServerMetrics() ([]Metric, error) {
-	c, err := a.httpClient()
+	c, err := a.serverClient()
 	if err != nil {
 		return nil, err
 	}
+	defer c.close()
 	raw, err := c.metricsRaw(a.ensureCtx())
 	if err != nil {
 		return nil, err
@@ -569,13 +577,13 @@ func (a *App) ensureCtx() context.Context {
 	return context.Background()
 }
 
-func (a *App) httpClient() (*httpClient, error) {
+func (a *App) serverClient() (*serverClient, error) {
 	s, err := a.requireStore()
 	if err != nil {
 		return nil, err
 	}
 	cfg := s.getSettings()
-	return newHTTPClient(cfg.ServerURL)
+	return newServerClient(cfg.ServerTransport, cfg.ServerURL)
 }
 
 // serverPublicKey decodes the configured server public key, or returns

--- a/clients/desktop/client.go
+++ b/clients/desktop/client.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -13,16 +15,88 @@ import (
 	"github.com/ryan-wong-coder/trustdb/sdk"
 )
 
-type httpClient struct {
-	sdk *sdk.Client
+type serverClient struct {
+	sdk       *sdk.Client
+	transport string
 }
 
-func newHTTPClient(base string) (*httpClient, error) {
-	client, err := sdk.NewClient(base)
+func newServerClient(transport, endpoint string) (*serverClient, error) {
+	transport = normalizeServerTransport(transport)
+	endpoint = strings.TrimSpace(endpoint)
+	var (
+		client *sdk.Client
+		err    error
+	)
+	switch transport {
+	case serverTransportHTTP:
+		client, err = sdk.NewClient(endpoint)
+	case serverTransportGRPC:
+		target, targetErr := normalizeGRPCTarget(endpoint)
+		if targetErr != nil {
+			return nil, targetErr
+		}
+		client, err = sdk.NewGRPCClient(target)
+	default:
+		return nil, fmt.Errorf("unsupported server transport: %s", transport)
+	}
 	if err != nil {
 		return nil, err
 	}
-	return &httpClient{sdk: client}, nil
+	return &serverClient{sdk: client, transport: transport}, nil
+}
+
+func normalizeServerTransport(transport string) string {
+	switch strings.ToLower(strings.TrimSpace(transport)) {
+	case "", serverTransportHTTP:
+		return serverTransportHTTP
+	case serverTransportGRPC:
+		return serverTransportGRPC
+	default:
+		return strings.ToLower(strings.TrimSpace(transport))
+	}
+}
+
+func validServerTransport(transport string) bool {
+	switch normalizeServerTransport(transport) {
+	case serverTransportHTTP, serverTransportGRPC:
+		return true
+	default:
+		return false
+	}
+}
+
+func normalizeGRPCTarget(endpoint string) (string, error) {
+	trimmed := strings.TrimSpace(endpoint)
+	if trimmed == "" {
+		return "", errors.New("grpc server target is empty")
+	}
+	if !strings.Contains(trimmed, "://") {
+		return strings.TrimRight(trimmed, "/"), nil
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("parse grpc target: %w", err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https", "grpc":
+		if u.Host == "" {
+			return "", fmt.Errorf("grpc target must include host: %s", trimmed)
+		}
+		if path := strings.Trim(u.Path, "/"); path != "" {
+			return "", fmt.Errorf("grpc target must be host:port, got path %q", u.Path)
+		}
+		return u.Host, nil
+	default:
+		// Keep advanced gRPC resolver targets such as dns:///host untouched.
+		return trimmed, nil
+	}
+}
+
+func (c *serverClient) close() {
+	if c == nil || c.sdk == nil {
+		return
+	}
+	_ = c.sdk.Close()
 }
 
 type ServerError = sdk.Error
@@ -30,16 +104,18 @@ type ServerError = sdk.Error
 type HealthStatus struct {
 	OK         bool   `json:"ok"`
 	ServerURL  string `json:"server_url"`
+	Transport  string `json:"transport"`
 	RTTMillis  int64  `json:"rtt_millis"`
 	Error      string `json:"error,omitempty"`
 	StatusCode int    `json:"status_code,omitempty"`
 }
 
-func (c *httpClient) health(ctx context.Context) HealthStatus {
+func (c *serverClient) health(ctx context.Context) HealthStatus {
 	status := c.sdk.CheckHealth(ctx)
 	return HealthStatus{
 		OK:         status.OK,
 		ServerURL:  status.ServerURL,
+		Transport:  c.transport,
 		RTTMillis:  status.RTTMillis,
 		Error:      status.Error,
 		StatusCode: status.StatusCode,
@@ -50,19 +126,19 @@ func (c *httpClient) health(ctx context.Context) HealthStatus {
 // batch_enqueued / idempotent flags without making a second call.
 type submitClaimResult = sdk.SubmitResult
 
-func (c *httpClient) submitSignedClaim(ctx context.Context, signed model.SignedClaim) (submitClaimResult, error) {
+func (c *serverClient) submitSignedClaim(ctx context.Context, signed model.SignedClaim) (submitClaimResult, error) {
 	return c.sdk.SubmitSignedClaim(ctx, signed)
 }
 
-func (c *httpClient) getProof(ctx context.Context, recordID string) (model.ProofBundle, error) {
+func (c *serverClient) getProof(ctx context.Context, recordID string) (model.ProofBundle, error) {
 	return c.sdk.GetProofBundle(ctx, recordID)
 }
 
-func (c *httpClient) getRecordIndex(ctx context.Context, recordID string) (model.RecordIndex, error) {
+func (c *serverClient) getRecordIndex(ctx context.Context, recordID string) (model.RecordIndex, error) {
 	return c.sdk.GetRecord(ctx, recordID)
 }
 
-func (c *httpClient) listRecordIndexes(ctx context.Context, opts RecordPageOptions) (RecordPage, error) {
+func (c *serverClient) listRecordIndexes(ctx context.Context, opts RecordPageOptions) (RecordPage, error) {
 	limit := opts.Limit
 	if limit <= 0 {
 		limit = 50
@@ -223,11 +299,11 @@ type anchorEnvelope struct {
 	Outbox   *model.STHAnchorOutboxItem `json:"outbox,omitempty"`
 }
 
-func (c *httpClient) getGlobalProof(ctx context.Context, batchID string) (model.GlobalLogProof, error) {
+func (c *serverClient) getGlobalProof(ctx context.Context, batchID string) (model.GlobalLogProof, error) {
 	return c.sdk.GetGlobalProof(ctx, batchID)
 }
 
-func (c *httpClient) getAnchor(ctx context.Context, treeSize uint64) (anchorEnvelope, error) {
+func (c *serverClient) getAnchor(ctx context.Context, treeSize uint64) (anchorEnvelope, error) {
 	status, err := c.sdk.GetAnchor(ctx, treeSize)
 	if err != nil {
 		if sdk.IsUnavailable(err) {
@@ -238,18 +314,18 @@ func (c *httpClient) getAnchor(ctx context.Context, treeSize uint64) (anchorEnve
 	return anchorEnvelope{TreeSize: status.TreeSize, Status: status.Status, Result: status.Result}, nil
 }
 
-func (c *httpClient) listRoots(ctx context.Context, limit int) ([]model.BatchRoot, error) {
+func (c *serverClient) listRoots(ctx context.Context, limit int) ([]model.BatchRoot, error) {
 	return c.sdk.ListRoots(ctx, limit)
 }
 
-func (c *httpClient) latestRoot(ctx context.Context) (model.BatchRoot, error) {
+func (c *serverClient) latestRoot(ctx context.Context) (model.BatchRoot, error) {
 	return c.sdk.LatestRoot(ctx)
 }
 
-func (c *httpClient) metricsRaw(ctx context.Context) (string, error) {
+func (c *serverClient) metricsRaw(ctx context.Context) (string, error) {
 	return c.sdk.MetricsRaw(ctx)
 }
 
-func (c *httpClient) exportSingleProof(ctx context.Context, recordID string) (model.SingleProof, error) {
+func (c *serverClient) exportSingleProof(ctx context.Context, recordID string) (model.SingleProof, error) {
 	return c.sdk.ExportSingleProof(ctx, recordID)
 }

--- a/clients/desktop/client_test.go
+++ b/clients/desktop/client_test.go
@@ -54,9 +54,9 @@ func TestHTTPClientListRecordIndexesMapsServerPage(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client, err := newHTTPClient(srv.URL)
+	client, err := newServerClient(serverTransportHTTP, srv.URL)
 	if err != nil {
-		t.Fatalf("newHTTPClient: %v", err)
+		t.Fatalf("newServerClient: %v", err)
 	}
 	page, err := client.listRecordIndexes(context.Background(), RecordPageOptions{
 		Limit:  2,
@@ -91,9 +91,9 @@ func TestHTTPClientListRecordIndexesSupportsExactRecordQuery(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client, err := newHTTPClient(srv.URL)
+	client, err := newServerClient(serverTransportHTTP, srv.URL)
 	if err != nil {
-		t.Fatalf("newHTTPClient: %v", err)
+		t.Fatalf("newServerClient: %v", err)
 	}
 	page, err := client.listRecordIndexes(context.Background(), RecordPageOptions{Query: "tr1exact"})
 	if err != nil {
@@ -133,9 +133,9 @@ func TestHTTPClientListRecordIndexesSendsServerSearchFilters(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client, err := newHTTPClient(srv.URL)
+	client, err := newServerClient(serverTransportHTTP, srv.URL)
 	if err != nil {
-		t.Fatalf("newHTTPClient: %v", err)
+		t.Fatalf("newServerClient: %v", err)
 	}
 	if _, err := client.listRecordIndexes(context.Background(), RecordPageOptions{Query: "screenshot"}); err != nil {
 		t.Fatalf("listRecordIndexes q: %v", err)
@@ -147,5 +147,31 @@ func TestHTTPClientListRecordIndexesSendsServerSearchFilters(t *testing.T) {
 	defer mu.Unlock()
 	if !sawTextQuery || !sawHashQuery {
 		t.Fatalf("saw text=%v hash=%v", sawTextQuery, sawHashQuery)
+	}
+}
+
+func TestNormalizeGRPCTargetStripsHTTPStyleURL(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		endpoint string
+		want     string
+	}{
+		{name: "host port", endpoint: "127.0.0.1:9090", want: "127.0.0.1:9090"},
+		{name: "http url", endpoint: "http://127.0.0.1:9090", want: "127.0.0.1:9090"},
+		{name: "grpc url", endpoint: "grpc://trustdb.example:9090/", want: "trustdb.example:9090"},
+		{name: "resolver target", endpoint: "dns:///trustdb.example:9090", want: "dns:///trustdb.example:9090"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := normalizeGRPCTarget(tc.endpoint)
+			if err != nil {
+				t.Fatalf("normalizeGRPCTarget: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("target = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/clients/desktop/frontend/src/components/Onboarding.vue
+++ b/clients/desktop/frontend/src/components/Onboarding.vue
@@ -42,22 +42,40 @@ const current = computed(() => steps[stepIdx.value])
 const progress = computed(() => ((stepIdx.value + 1) / steps.length) * 100)
 
 // --- Step 2: server config ---------------------------------------
-const serverUrl     = ref(settings.settings.server_url     || 'http://127.0.0.1:8080')
-const serverPubKey  = ref(settings.settings.server_public_key_b64 || '')
-const testingServer = ref(false)
-const serverChecked = ref<null | { ok: boolean; message: string }>(null)
+const serverTransport = ref(settings.settings.server_transport || 'http')
+const serverUrl       = ref(settings.settings.server_url || 'http://127.0.0.1:8080')
+const serverPubKey    = ref(settings.settings.server_public_key_b64 || '')
+const testingServer   = ref(false)
+const serverChecked   = ref<null | { ok: boolean; message: string }>(null)
+
+const TRANSPORTS = [
+  { v: 'http', label: 'HTTP', desc: '默认 REST 接入' },
+  { v: 'grpc', label: 'gRPC', desc: 'SDK 直连 RPC' },
+]
+const serverEndpointHint = computed(() =>
+  serverTransport.value === 'grpc'
+    ? '例如 127.0.0.1:9090；误填 http://host:port 也会自动转成 host:port'
+    : '例如 http://127.0.0.1:8080；也可以填远端 HTTPS',
+)
+const serverEndpointPlaceholder = computed(() =>
+  serverTransport.value === 'grpc' ? '127.0.0.1:9090' : 'http://127.0.0.1:8080',
+)
 
 async function testServer() {
   testingServer.value = true
   serverChecked.value = null
   try {
     // Persist first so api.serverHealth (which reads settings from
-    // the Go store) sees the user's URL instead of whatever was on
-    // disk before the wizard opened.
-    await settings.save({ server_url: serverUrl.value.trim(), server_public_key_b64: serverPubKey.value.trim() })
+    // the Go store) sees the user's transport/endpoint instead of
+    // whatever was on disk before the wizard opened.
+    await settings.save({
+      server_transport: serverTransport.value,
+      server_url: serverUrl.value.trim(),
+      server_public_key_b64: serverPubKey.value.trim(),
+    })
     const h = await api.serverHealth()
     if (h?.ok) {
-      serverChecked.value = { ok: true, message: `服务正常 · ${h.rtt_millis ?? '?'}ms` }
+      serverChecked.value = { ok: true, message: `${(h.transport || serverTransport.value).toUpperCase()} 服务正常 · ${h.rtt_millis ?? '?'}ms` }
     } else {
       serverChecked.value = { ok: false, message: h?.error || '服务未就绪' }
     }
@@ -149,7 +167,11 @@ function finish() {
   // Persist the settings from step 2 one more time in case the user
   // edited them after the connection test succeeded, then remember
   // that the wizard has been seen so it doesn't reopen next launch.
-  settings.save({ server_url: serverUrl.value.trim(), server_public_key_b64: serverPubKey.value.trim() })
+  settings.save({
+    server_transport: serverTransport.value,
+    server_url: serverUrl.value.trim(),
+    server_public_key_b64: serverPubKey.value.trim(),
+  })
   try { localStorage.setItem('trustdb.onboarded', '1') } catch { /* ignore */ }
   emit('close')
 }
@@ -235,8 +257,25 @@ function skip() {
 
           <!-- 2. Server -->
           <div v-else-if="current.key === 'server'" class="space-y-3">
-            <Field label="服务地址" hint="例如 http://127.0.0.1:8080；也可以填远端 HTTPS">
-              <Input v-model="serverUrl" placeholder="http://127.0.0.1:8080" />
+            <Field label="传输协议" hint="HTTP 兼容现有服务；gRPC 用于连接已开启 --grpc-listen 的服务端">
+              <div class="grid grid-cols-2 gap-2">
+                <button
+                  v-for="t in TRANSPORTS"
+                  :key="t.v"
+                  type="button"
+                  class="rounded-[18px] border px-4 py-3 text-left transition-all duration-150"
+                  :class="serverTransport === t.v
+                    ? 'border-accent bg-accent/15 text-ink-50 shadow-[0_0_22px_rgba(0,255,34,0.16)]'
+                    : 'border-white/10 bg-black/20 text-ink-400 hover:border-white/20 hover:text-ink-100'"
+                  @click="serverTransport = t.v"
+                >
+                  <div class="font-display text-[13px] font-black tracking-[0.12em]">{{ t.label }}</div>
+                  <div class="mt-1 text-[11.5px] opacity-75">{{ t.desc }}</div>
+                </button>
+              </div>
+            </Field>
+            <Field :label="serverTransport === 'grpc' ? 'gRPC Target' : '服务地址'" :hint="serverEndpointHint">
+              <Input v-model="serverUrl" :placeholder="serverEndpointPlaceholder" />
             </Field>
             <Field label="服务端公钥（base64）" hint="从 server.pub 复制内容，留空也可以先跳过">
               <Input v-model="serverPubKey" placeholder="Zo46rzMjDyCXRa5-4bSqASte5A0JOLWOJ2mkeKzaCXw" />

--- a/clients/desktop/frontend/src/components/Sidebar.vue
+++ b/clients/desktop/frontend/src/components/Sidebar.vue
@@ -40,6 +40,7 @@ const settings = useSettings()
 const { settings: cfg } = storeToRefs(settings)
 
 const activePath = computed(() => route.path)
+const endpointTransport = computed(() => (cfg.value.server_transport || 'http').toUpperCase())
 
 function isActive(to: string): boolean {
   return activePath.value === to || (to === '/dashboard' && activePath.value === '/')
@@ -97,6 +98,7 @@ function isActive(to: string): boolean {
     <footer class="px-4 py-4 hairline-t no-drag">
       <div class="rounded-[16px] border border-accent/20 bg-accent/10 p-3">
         <div class="kicker text-[9px] font-bold">Endpoint</div>
+        <div class="mt-1 font-mono text-[10px] text-accent">{{ endpointTransport }}</div>
         <div class="mt-1 truncate font-mono text-[11px] text-ink-200">{{ cfg.server_url || '未配置服务器' }}</div>
       </div>
     </footer>

--- a/clients/desktop/frontend/src/pages/Settings.vue
+++ b/clients/desktop/frontend/src/pages/Settings.vue
@@ -24,6 +24,7 @@ watch(
 const dirty = computed(() => {
   return (
     form.server_url !== settings.settings.server_url ||
+    form.server_transport !== settings.settings.server_transport ||
     form.server_public_key_b64 !== settings.settings.server_public_key_b64 ||
     form.default_media_type !== settings.settings.default_media_type ||
     form.default_event_type !== settings.settings.default_event_type ||
@@ -55,8 +56,8 @@ async function ping() {
   pingLoading.value = true
   pingResult.value = null
   try {
-    // Temporarily persist so the backend's httpClient picks up the
-    // new URL. We restore afterwards if the user didn't click "Save".
+    // Temporarily persist so the backend's server client picks up the
+    // new transport and endpoint. We restore afterwards if the user didn't click "Save".
     const previous = { ...settings.settings }
     await settings.save({ ...form })
     try {
@@ -73,6 +74,19 @@ async function ping() {
     pingLoading.value = false
   }
 }
+
+const TRANSPORTS = [
+  { v: 'http', label: 'HTTP', desc: '默认 REST 接入' },
+  { v: 'grpc', label: 'gRPC', desc: 'SDK 直连 RPC' },
+]
+const endpointHint = computed(() =>
+  form.server_transport === 'grpc'
+    ? '例：127.0.0.1:9090；如果误填 http://host:port，客户端会自动归一化为 host:port'
+    : '例：http://localhost:8081；结尾的 / 可省略',
+)
+const endpointPlaceholder = computed(() =>
+  form.server_transport === 'grpc' ? '127.0.0.1:9090' : 'http://host:port',
+)
 
 const THEMES = [
   { v: 'auto',  label: '跟随系统', icon: Monitor    },
@@ -94,8 +108,25 @@ function reopenOnboarding() {
   <div class="flex flex-col gap-5 max-w-[900px] mx-auto">
     <Card title="服务器" subtitle="TrustDB 服务端的入口和信任锚">
       <div class="space-y-3">
-        <Field label="服务器 URL" hint="例：http://localhost:8081；结尾的 / 可省略">
-          <Input v-model="form.server_url" placeholder="http://host:port" :mono="true" />
+        <Field label="传输协议" hint="HTTP 继续兼容现有服务；gRPC 适合配合 Go SDK / 内网服务使用">
+          <div class="grid grid-cols-2 gap-2">
+            <button
+              v-for="t in TRANSPORTS"
+              :key="t.v"
+              type="button"
+              class="rounded-[18px] border px-4 py-3 text-left transition-all duration-150"
+              :class="form.server_transport === t.v
+                ? 'border-accent bg-accent/15 text-ink-50 shadow-[0_0_22px_rgba(0,255,34,0.16)]'
+                : 'border-white/10 bg-black/20 text-ink-400 hover:border-white/20 hover:text-ink-100'"
+              @click="form.server_transport = t.v"
+            >
+              <div class="font-display text-[13px] font-black tracking-[0.12em]">{{ t.label }}</div>
+              <div class="mt-1 text-[11.5px] opacity-75">{{ t.desc }}</div>
+            </button>
+          </div>
+        </Field>
+        <Field :label="form.server_transport === 'grpc' ? 'gRPC Target' : '服务器 URL'" :hint="endpointHint">
+          <Input v-model="form.server_url" :placeholder="endpointPlaceholder" :mono="true" />
         </Field>
         <Field label="服务器公钥 (base64)" hint="用于验证 AcceptedReceipt / CommittedReceipt 的签名">
           <Input v-model="form.server_public_key_b64" placeholder="Ed25519 public key" :mono="true" multiline :rows="2" />
@@ -107,6 +138,8 @@ function reopenOnboarding() {
             <span class="text-ink-700 dark:text-ink-200">
               {{ pingResult.ok ? `在线 · ${pingResult.rtt_millis}ms` : (pingResult.error || '离线') }}
             </span>
+            <span class="text-ink-400">·</span>
+            <span class="text-ink-500 font-mono uppercase">{{ pingResult.transport || form.server_transport || 'http' }}</span>
             <span class="text-ink-400">·</span>
             <span class="text-ink-500 font-mono">{{ pingResult.server_url }}</span>
           </div>

--- a/clients/desktop/frontend/src/pages/Verify.vue
+++ b/clients/desktop/frontend/src/pages/Verify.vue
@@ -37,6 +37,7 @@ const showSplitProofs = ref(false)
 // Remote-only
 const recordID = ref('')
 const serverURL = ref('')
+const configuredTransport = computed(() => (settings.settings.server_transport || 'http').toUpperCase())
 
 const running = ref(false)
 const result = ref<VerifyResponse | null>(null)
@@ -148,7 +149,8 @@ function stepState(s: Step): 'pass' | 'current' | 'todo' | 'fail' {
           需要逐级审计时，可以展开下方的分布式证明入口。
         </template>
         <template v-else>
-          输入 record_id，客户端会从 <span class="font-mono">{{ serverURL || settings.settings.server_url || '（未配置）' }}</span>
+          输入 record_id，客户端会按设置里的 <span class="font-mono">{{ configuredTransport }}</span>
+          transport 从 <span class="font-mono">{{ serverURL || settings.settings.server_url || '（未配置）' }}</span>
           拉取 proof bundle、GlobalLogProof 和 STH anchor 并就地验证。
         </template>
       </p>
@@ -231,8 +233,8 @@ function stepState(s: Step): 'pass' | 'current' | 'todo' | 'fail' {
           <Field label="record_id" hint="服务端返回的 64 位十六进制 ID">
             <Input v-model="recordID" placeholder="例如 2e9d…" :mono="true" />
           </Field>
-          <Field label="服务器 URL（可选）" :hint="`默认使用设置里的 ${settings.settings.server_url || 'http://localhost:8081'}`">
-            <Input v-model="serverURL" placeholder="http://host:8081" />
+          <Field label="服务器地址（可选）" :hint="`默认使用设置里的 ${configuredTransport} · ${settings.settings.server_url || 'http://localhost:8081'}`">
+            <Input v-model="serverURL" :placeholder="configuredTransport === 'GRPC' ? '127.0.0.1:9090' : 'http://host:8081'" />
           </Field>
         </template>
 

--- a/clients/desktop/frontend/src/stores/settings.ts
+++ b/clients/desktop/frontend/src/stores/settings.ts
@@ -4,6 +4,7 @@ import { api, Settings } from '@/lib/api'
 
 const defaultSettings: Settings = {
   server_url: 'http://127.0.0.1:8080',
+  server_transport: 'http',
   server_public_key_b64: '',
   default_media_type: 'application/octet-stream',
   default_event_type: 'file.snapshot',
@@ -18,7 +19,7 @@ export const useSettings = defineStore('settings', () => {
     loading.value = true
     try {
       const s = await api.getSettings()
-      settings.value = s ?? { ...defaultSettings }
+      settings.value = { ...defaultSettings, ...(s ?? {}) }
       applyTheme(settings.value.theme)
     } finally {
       loading.value = false
@@ -26,7 +27,7 @@ export const useSettings = defineStore('settings', () => {
   }
 
   async function save(partial: Partial<Settings>) {
-    const next = { ...settings.value, ...partial } as Settings
+    const next = { ...defaultSettings, ...settings.value, ...partial } as Settings
     await api.saveSettings(next)
     settings.value = next
     applyTheme(next.theme)

--- a/clients/desktop/frontend/wailsjs/go/models.ts
+++ b/clients/desktop/frontend/wailsjs/go/models.ts
@@ -246,6 +246,7 @@ export namespace main {
 	export class HealthStatus {
 	    ok: boolean;
 	    server_url: string;
+	    transport: string;
 	    rtt_millis: number;
 	    error?: string;
 	    status_code?: number;
@@ -258,6 +259,7 @@ export namespace main {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.ok = source["ok"];
 	        this.server_url = source["server_url"];
+	        this.transport = source["transport"];
 	        this.rtt_millis = source["rtt_millis"];
 	        this.error = source["error"];
 	        this.status_code = source["status_code"];
@@ -380,6 +382,7 @@ export namespace main {
 	}
 	export class Settings {
 	    server_url: string;
+	    server_transport: string;
 	    server_public_key_b64: string;
 	    default_media_type: string;
 	    default_event_type: string;
@@ -392,6 +395,7 @@ export namespace main {
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.server_url = source["server_url"];
+	        this.server_transport = source["server_transport"];
 	        this.server_public_key_b64 = source["server_public_key_b64"];
 	        this.default_media_type = source["default_media_type"];
 	        this.default_event_type = source["default_event_type"];

--- a/clients/desktop/store.go
+++ b/clients/desktop/store.go
@@ -32,11 +32,17 @@ type Identity struct {
 // we can verify responses, and UI preferences.
 type Settings struct {
 	ServerURL       string `json:"server_url"`
+	ServerTransport string `json:"server_transport"`
 	ServerPubKeyB64 string `json:"server_public_key_b64"`
 	DefaultMedia    string `json:"default_media_type"`
 	DefaultEvent    string `json:"default_event_type"`
 	Theme           string `json:"theme"`
 }
+
+const (
+	serverTransportHTTP = "http"
+	serverTransportGRPC = "grpc"
+)
 
 // LocalRecord is everything we remember about a submission we sent
 // from this workstation: enough to show a rich Record detail page
@@ -149,10 +155,11 @@ type store struct {
 
 func defaultSettings() Settings {
 	return Settings{
-		ServerURL:    "http://127.0.0.1:8080",
-		DefaultMedia: "application/octet-stream",
-		DefaultEvent: "file.snapshot",
-		Theme:        "auto",
+		ServerURL:       "http://127.0.0.1:8080",
+		ServerTransport: serverTransportHTTP,
+		DefaultMedia:    "application/octet-stream",
+		DefaultEvent:    "file.snapshot",
+		Theme:           "auto",
 	}
 }
 
@@ -196,8 +203,10 @@ func (s *store) load() error {
 		}
 	}
 	if loaded.Settings.ServerURL == "" {
-		loaded.Settings = defaultSettings()
+		defaults := defaultSettings()
+		loaded.Settings.ServerURL = defaults.ServerURL
 	}
+	loaded.Settings.ServerTransport = normalizeServerTransport(loaded.Settings.ServerTransport)
 	if loaded.Settings.DefaultMedia == "" {
 		loaded.Settings.DefaultMedia = "application/octet-stream"
 	}
@@ -298,6 +307,7 @@ func (s *store) getSettings() Settings {
 func (s *store) setSettings(cfg Settings) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	cfg.ServerTransport = normalizeServerTransport(cfg.ServerTransport)
 	if cfg.DefaultMedia == "" {
 		cfg.DefaultMedia = "application/octet-stream"
 	}

--- a/clients/desktop/store_test.go
+++ b/clients/desktop/store_test.go
@@ -21,6 +21,9 @@ func TestStoreLoadMissingConfigUsesDefaults(t *testing.T) {
 	if cfg.ServerURL != "http://127.0.0.1:8080" {
 		t.Fatalf("ServerURL = %q, want default", cfg.ServerURL)
 	}
+	if cfg.ServerTransport != serverTransportHTTP {
+		t.Fatalf("ServerTransport = %q, want http", cfg.ServerTransport)
+	}
 }
 
 func TestWailsRecordDTOsDoNotExposeTimeTime(t *testing.T) {
@@ -85,6 +88,9 @@ func TestStoreLoadAcceptsUTF8BOM(t *testing.T) {
 	cfg := store.getSettings()
 	if cfg.ServerURL != "http://127.0.0.1:8081" {
 		t.Fatalf("ServerURL = %q, want 8081", cfg.ServerURL)
+	}
+	if cfg.ServerTransport != serverTransportHTTP {
+		t.Fatalf("ServerTransport = %q, want http", cfg.ServerTransport)
 	}
 }
 

--- a/clients/desktop/submit.go
+++ b/clients/desktop/submit.go
@@ -84,10 +84,11 @@ func (a *App) SubmitFile(req SubmitRequest) (*SubmitResult, error) {
 		return nil, err
 	}
 
-	c, err := a.httpClient()
+	c, err := a.serverClient()
 	if err != nil {
 		return nil, err
 	}
+	defer c.close()
 	resp, err := c.submitSignedClaim(a.ensureCtx(), signed)
 	if err != nil {
 		return nil, err
@@ -174,10 +175,11 @@ func (a *App) RefreshRecord(recordID string) (*LocalRecord, error) {
 		return nil, err
 	}
 	rec, ok := st.getRecord(recordID)
-	c, err := a.httpClient()
+	c, err := a.serverClient()
 	if err != nil {
 		return nil, err
 	}
+	defer c.close()
 	if !ok {
 		idx, err := c.getRecordIndex(a.ensureCtx(), recordID)
 		if err != nil {
@@ -237,10 +239,11 @@ func (a *App) ExportProofBundle(recordID, outPath string) error {
 	if outPath == "" {
 		return errors.New("output path required")
 	}
-	c, err := a.httpClient()
+	c, err := a.serverClient()
 	if err != nil {
 		return err
 	}
+	defer c.close()
 	bundle, err := c.getProof(a.ensureCtx(), recordID)
 	if err != nil {
 		return err
@@ -258,10 +261,11 @@ func (a *App) ExportGlobalProof(recordID, outPath string) error {
 	if outPath == "" {
 		return errors.New("output path required")
 	}
-	c, err := a.httpClient()
+	c, err := a.serverClient()
 	if err != nil {
 		return err
 	}
+	defer c.close()
 	bundle, err := c.getProof(a.ensureCtx(), recordID)
 	if err != nil {
 		return err
@@ -296,10 +300,11 @@ func (a *App) ExportSingleProof(recordID, outPath string) error {
 }
 
 func (a *App) buildSingleProof(recordID string) (model.SingleProof, error) {
-	c, err := a.httpClient()
+	c, err := a.serverClient()
 	if err != nil {
 		return model.SingleProof{}, err
 	}
+	defer c.close()
 	proof, err := c.exportSingleProof(a.ensureCtx(), recordID)
 	if err != nil {
 		return model.SingleProof{}, err
@@ -419,9 +424,10 @@ func (a *App) ExportAnchorResult(recordID, outPath string) error {
 // (verify page uses it so the user doesn't have to export-then-
 // re-import just to view the batch details).
 func (a *App) GetProofBundle(recordID string) (model.ProofBundle, error) {
-	c, err := a.httpClient()
+	c, err := a.serverClient()
 	if err != nil {
 		return model.ProofBundle{}, err
 	}
+	defer c.close()
 	return c.getProof(a.ensureCtx(), recordID)
 }

--- a/clients/desktop/verify.go
+++ b/clients/desktop/verify.go
@@ -120,6 +120,7 @@ func (a *App) VerifyProof(req VerifyRequest) (*VerifyResponse, error) {
 		if err != nil {
 			return nil, err
 		}
+		defer c.close()
 		bundle, err = c.getProof(a.ensureCtx(), req.RecordID)
 		if err != nil {
 			return nil, fmt.Errorf("fetch proof: %w", err)
@@ -185,11 +186,17 @@ func (a *App) VerifyProof(req VerifyRequest) (*VerifyResponse, error) {
 	}, nil
 }
 
-func (a *App) remoteClient(override string) (*httpClient, error) {
-	if override != "" {
-		return newHTTPClient(override)
+func (a *App) remoteClient(override string) (*serverClient, error) {
+	if override == "" {
+		return a.serverClient()
 	}
-	return a.httpClient()
+	s, err := a.requireStore()
+	if err != nil {
+		return nil, err
+	}
+	cfg := s.getSettings()
+	cfg.ServerURL = override
+	return newServerClient(cfg.ServerTransport, cfg.ServerURL)
 }
 
 func (a *App) resolveClientPub(bundle model.ProofBundle, override string) (ed25519.PublicKey, error) {


### PR DESCRIPTION
## Summary

- 在桌面端设置与初始化引导中显式加入 HTTP/gRPC transport 切换。
- Wails App 根据 `server_transport` 创建 HTTP 或 gRPC Go SDK client，旧配置默认 HTTP。
- gRPC 模式支持 `host:port`，并对 `http://host:port` / `grpc://host:port` 做归一化。
- 远程记录、提交、刷新、导出证明、远程验证等路径统一复用 server client，并在调用后关闭 SDK client，避免 gRPC 连接泄漏。
- 设置侧栏与远程验证说明展示当前 transport。

Closes #89

## Tests

- `go test ./clients/desktop`
- `cd clients/desktop/frontend && npm run build`
- `go test ./...`
- `go vet ./...`
- `cd clients/desktop && go vet ./...`
- `cd clients/desktop && go test -race ./...`
- `go test -race ./...`
- `go test -tags=integration ./...`
- `go test -tags=e2e ./...`
- `cd clients/desktop && wails build`