### PR TITLE
[codex] Fix remote verify skip-anchor L4 semantics

### DIFF
--- a/cmd/trustdb/verify_cmd.go
+++ b/cmd/trustdb/verify_cmd.go
@@ -218,12 +218,12 @@ func loadVerifyInputs(
 	if err != nil {
 		return model.ProofBundle{}, nil, nil, err
 	}
-	if skipAnchor {
-		return bundle, nil, nil, nil
-	}
 	global, err := fetchGlobalProof(ctx, client, serverURL, bundle.CommittedReceipt.BatchID)
 	if err != nil {
 		return model.ProofBundle{}, nil, nil, err
+	}
+	if skipAnchor {
+		return bundle, &global, nil, nil
 	}
 	ar, err := fetchAnchorResult(ctx, client, serverURL, global.STH.TreeSize)
 	if err != nil {

--- a/cmd/trustdb/verify_cmd_test.go
+++ b/cmd/trustdb/verify_cmd_test.go
@@ -86,8 +86,8 @@ func TestVerifyCmdRemoteAnchor(t *testing.T) {
 }
 
 // TestVerifyCmdRemoteSkipAnchor exercises the same remote flow but
-// with --skip-anchor so the command stops at L3 even though the
-// server has a published anchor available.
+// with --skip-anchor so the command still verifies L4 global-log evidence
+// while ignoring the published L5 anchor.
 func TestVerifyCmdRemoteSkipAnchor(t *testing.T) {
 	ctx := context.Background()
 
@@ -115,8 +115,8 @@ func TestVerifyCmdRemoteSkipAnchor(t *testing.T) {
 	if err := json.Unmarshal(outBuf.Bytes(), &result); err != nil {
 		t.Fatalf("decode output: %v", err)
 	}
-	if !result.Valid || result.ProofLevel != "L3" {
-		t.Fatalf("verify result = %+v, want L3 valid", result)
+	if !result.Valid || result.ProofLevel != "L4" {
+		t.Fatalf("verify result = %+v, want L4 valid", result)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix remote `trustdb verify --server ... --skip-anchor` so it still fetches and verifies GlobalLogProof.
- Keep `--skip-anchor` scoped to suppressing only the L5 anchor fetch/result.
- Update the remote skip-anchor regression test to expect L4 instead of L3.

## Root Cause

The remote `loadVerifyInputs` path returned immediately when `skipAnchor` was true, before fetching GlobalLogProof. That made the CLI stop at L3 even though local `.sproof`, desktop, and SDK verification semantics treat skip-anchor as "skip only L5 anchor".

## Validation

- `GOCACHE=$PWD/.gocache go test ./cmd/trustdb -run TestVerifyCmdRemoteSkipAnchor -count=1 -v`
- `GOCACHE=$PWD/.gocache go test ./...`

Closes #91