### PR TITLE
修正桌面客户端安装包命名为 trustdb

### DIFF
--- a/clients/desktop/wails.json
+++ b/clients/desktop/wails.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://wails.io/schemas/config.v2.json",
-  "name": "desktop",
-  "outputfilename": "desktop",
+  "name": "trustdb",
+  "outputfilename": "trustdb",
   "frontend:install": "npm install",
   "frontend:build": "npm run build",
   "frontend:dev:watcher": "npm run dev",


### PR DESCRIPTION
## Summary
- 将 Wails 桌面客户端 `name` 从 `desktop` 改为 `trustdb`
- 将 Wails 输出文件名从 `desktop` 改为 `trustdb`
- 重新验证 Windows NSIS 安装器输出为 `trustdb-amd64-installer.exe`

## Validation
- `wails build -clean -nsis`

Closes #95