### PR TITLE
重写 CONTRIBUTING 为中英双文架构导向指南

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,315 +1,419 @@
-# TrustDB 代码贡献指南
+﻿# TrustDB 贡献指南 / Contributing Guide
 
-这份文档说明 TrustDB 仓库的代码贡献方式。它面向后续的功能开发、Bug 修复、重构、文档更新、测试补齐和工程质量收敛。
+TrustDB 是一个单机可验证存证数据库。贡献代码时，最重要的不是遵守某个表面风格，而是保护证明语义、持久化边界、恢复能力和大规模数据路径。本指南面向功能开发、Bug 修复、重构、文档、测试和发布维护。
 
-TrustDB 当前采用 Issue-first 流程：先把问题和验收标准写清楚，再开发。
+This document is bilingual. The Chinese section is authoritative for day-to-day project conventions; the English section mirrors the same expectations for international contributors.
 
-## 基本原则
+## 中文版
 
-- 先提 Issue，再写代码。没有 Issue 的开发不进入实现阶段。
-- 每个变更都要能追溯到一个 Issue，提交信息或 PR 描述中引用对应编号。
-- 只提交与当前 Issue 相关的变更，避免把无关格式化、实验代码、本地数据混在一起。
-- README 和贡献文档只能描述当前已经实现的能力，不把路线图写成现状。
-- 任何证明语义、存储格式、CLI/API 行为变化，都要同步更新测试和用户可见文档。
-- 不提交本地运行数据、密钥、数据库目录、备份包、构建产物或私有部署配置。
+### 贡献原则
 
-## 开发前准备
+- Issue first：任何开发、重构、文档发布或行为变更都先创建 Issue，写清背景、目标、非目标、风险和验收标准。
+- Small pull requests：一个 PR 只解决一个 Issue，不混入无关格式化、实验代码、本地数据或顺手重构。
+- Current implementation only：README、贡献指南和用户文档只能描述已经实现的能力，不把路线图写成现状。
+- Tests protect semantics：涉及证明、存储、恢复、API、SDK 或桌面客户端行为时，测试要覆盖语义边界和失败路径，而不只覆盖 happy path。
+- Review before merge：`main` 受 CODEOWNERS 和分支保护约束，合并前需要通过 CI 和维护者 review。
+- Security by default：私钥、生产配置、本地数据库、备份包、构建产物和部署状态不得进入 Git。
 
-推荐环境：
+### 仓库架构地图
 
-- Go：使用 `go.mod` 中声明的版本。
-- Git：用于分支、提交和远程同步。
-- Node.js / npm：用于 `clients/desktop/frontend`。
-- Wails：仅在需要构建桌面客户端安装包时需要。
-- Windows race/Wails 构建如遇 CGO 编译错误，需要先配置可用的 C/C++ 编译环境。
-
-克隆仓库：
-
-```powershell
-git clone git@github.com:ryan-wong-coder/trustdb.git
-cd trustdb
-```
-
-拉取依赖并校验：
-
-```powershell
-go mod download
-go mod verify
-
-cd clients/desktop
-go mod download
-go mod verify
-
-cd frontend
-npm ci
-```
-
-## Issue-first 流程
-
-每个开发任务先创建 GitHub Issue。Issue 至少包含：
-
-- 背景 / 问题
-- 目标
-- 非目标
-- 影响范围
-- 实现方案或候选方案
-- 验收标准
-- 测试计划
-- 风险与回滚
-
-如果任务涉及架构、证明等级、存储格式、备份格式、外部锚定或公开 API，Issue 中必须先写清楚兼容性边界和安全影响。
-
-仓库提供了 GitHub Issue 模板：
-
-- Bug report：用于已实现路径的缺陷。
-- Feature request：用于新增能力。
-- Engineering task：用于重构、CI、文档、部署和维护任务。
-
-不要绕过模板直接开空白 Issue；如果模板不够用，先在 Issue 内容中解释缺失字段，而不是省略背景、验收和验证。
-
-## 分支规范
-
-从最新 `main` 创建分支：
-
-```powershell
-git switch main
-git pull --ff-only
-git switch -c issue-<number>-<short-name>
-```
-
-示例：
-
-```powershell
-git switch -c issue-2-contributing-guide
-```
-
-分支命名建议：
-
-- `issue-<number>-<short-name>`：常规功能、修复、文档任务。
-- `hotfix-<number>-<short-name>`：紧急修复。
-- `spike-<number>-<short-name>`：探索性验证。探索结果合并前要收敛成正式实现或文档。
-
-不要直接在 `main` 上开发。
-
-## 提交规范
-
-提交信息使用简洁祈使句，并引用 Issue：
+TrustDB 当前是单机架构，但内部按可信边界拆分。贡献前请先判断你的改动落在哪个边界内。
 
 ```text
-Add contribution guide
+cmd/trustdb
+  CLI entrypoint and server wiring
 
-Refs #2
+internal/model
+  Canonical proof, receipt, STH, anchor, backup, and API data models
+
+internal/cborx + internal/trustcrypto
+  Deterministic CBOR encoding and cryptographic signing/hash utilities
+
+internal/claim + internal/receipt + internal/verify + internal/prooflevel
+  Claim construction, accepted receipts, local verification, and L1-L5 semantics
+
+internal/ingest + internal/wal
+  Bounded ingest queue, accepted-write durability, WAL replay, fsync policy, checkpoints
+
+internal/batch + internal/merkle
+  Batch construction, Merkle roots, proof bundles, committed root metadata
+
+internal/globallog
+  Global Transparency Log, STH generation, inclusion proofs, consistency proofs, tiles/frontier state
+
+internal/anchor
+  STH/global-root anchor outbox, sinks, retry/upgrade behavior, OpenTimestamps integration
+
+internal/proofstore + internal/proofstore/pebble
+  File and Pebble proofstore implementations, indexes, cursor/range access, persisted artifacts
+
+internal/httpapi + internal/grpcapi
+  Public service surfaces for HTTP and gRPC, preserving shared proof object semantics
+
+internal/backup + internal/sproof
+  Portable backup/restore and single-file proof exchange formats
+
+sdk
+  Public Go SDK used by automation and the desktop client transport layer
+
+clients/desktop
+  Wails + Vue desktop app, local identity, server settings, Pebble-backed local record index, proof export/verify
+
+configs + formats + scripts
+  Supported configuration profiles, stable public file-format docs, and release/development helpers
 ```
 
-修复类提交可以使用：
+### 数据流和可信边界
 
 ```text
-Fix WAL replay memory spike
-
-Fixes #12
+File -> SignedClaim -> AcceptedReceipt -> ProofBundle -> GlobalLogProof -> STHAnchorResult
+       L1             L2                L3             L4              L5
 ```
 
-提交前检查：
+- L1：客户端对包含文件哈希和元数据的 claim 签名。
+- L2：服务端校验 claim，并在 WAL durable boundary 内接受。
+- L3：batch worker 将 accepted records 提交进 Merkle batch，生成 `ProofBundle`。
+- L4：batch root 进入 Global Transparency Log，并能证明其包含在某个 STH 中。
+- L5：对应 STH/global root 被外部 anchor sink 锚定。
 
-```powershell
-git status --short
-git diff
-```
+关键边界：
 
-确认没有以下内容被提交：
+- L4 不等于外部锚定。L4 只证明 batch root 已进入 global log。
+- L5 只锚定 STH/global root，不恢复 per-batch root 直锚模式。
+- `.sproof` 是主要交换格式；`.tdproof`、`.tdgproof`、`.tdanchor-result` 是高级分步格式。
+- 验证器必须独立复算 proof、hash 和 signature，不能信任服务端返回的等级标签。
 
-- `.trustdb/`、`.trustdb-dev/`、`.localtest/`、`.localdeploy/`
-- `node_modules/`、`dist/`、`build/`、`release/`
-- `*.key`、`*.pub`、`*.pem`、`*.tdkeys`
-- `.env`、备份包、临时文件、日志文件
-- 与当前 Issue 无关的格式化或实验文件
+### 变更类型与架构责任
 
-开发完成后必须把分支 push 到远程，并通过 Pull Request 合并；不要只停留在本地提交，也不要直接 push 到 `main`：
+| 变更范围 | 主要关注点 | 常见测试 |
+| --- | --- | --- |
+| Proof/model/encoding | 确定性 CBOR、hash/signature input、兼容性声明、篡改失败测试 | `go test ./...`，格式/验证回归测试 |
+| WAL/ingest/replay | durable boundary、幂等 replay、checkpoint、崩溃窗口、内存峰值 | unit、race、integration |
+| Batch/global log | Merkle root 稳定性、proof 可恢复、consistency proof、避免 O(N) 主路径 | unit、benchmark、integration/e2e |
+| Proofstore/Pebble | key schema、二级索引、cursor/range API、file backend 降级语义 | proofstore tests、large-path tests |
+| Anchor/OTS | STH-only 语义、outbox retry、next_attempt_at、外部服务失败隔离 | unit、integration with fake sink |
+| HTTP/gRPC/SDK | transport parity、错误可自动化判断、CBOR payload 语义一致 | unit、e2e、SDK tests |
+| Desktop client | Go SDK transport、Pebble-backed local index、分页/虚拟列表、`.sproof` 主路径 | desktop Go tests、frontend build、manual smoke |
+| Backup/restore | 流式处理、entry hash、resume checkpoint、重复 restore 幂等 | backup tests、interruption tests |
+| Documentation | 只描述当前实现、同步中英入口、命令和路径可验证 | `git diff --check` |
 
-```powershell
-git push -u origin issue-<number>-<short-name>
-```
+### 架构不变量
 
-## 工程约束
+#### 证明语义
 
-TrustDB 不是普通 CRUD 服务，贡献时要优先保护证明语义、持久化边界、恢复能力和大规模数据路径。下面这些约束比个人代码风格更重要。
+- L1-L5 的含义必须在 CLI、HTTP、gRPC、SDK、桌面客户端和验证器之间保持一致。
+- 任何 proof object 的字段、编码、hash input 或 signature input 变化，都必须明确兼容性边界。
+- 安全失败不得被降级成成功、unknown 或仅 UI 警告。
+- 回归测试应覆盖被篡改 artifact、错误公钥、错误 batch root、错误 STH、缺失 anchor 等失败路径。
 
-### 证明语义
+#### 持久化与恢复
 
-- L1/L2/L3/L4/L5 的含义不能在 UI、CLI、HTTP API 和验证器之间出现分叉。
-- L4 只表示 batch root 已进入 Global Transparency Log，并能证明它包含在某个 STH 中。
-- L5 只表示对应 STH/global root 已被外部 notary 锚定；不要恢复 batch root 直锚模式。
-- `.sproof` 是主要交换格式；`.tdproof`、`.tdgproof`、`.tdanchor-result` 是高级分步格式，不能让两套路径得出不同结论。
-- 任何证明对象的字段、编码、hash input、signature input 变化，都必须有向后兼容说明或明确声明不兼容，并补充验证测试。
+- WAL accepted、batch committed、global log appended、anchor published 是不同耐久边界。
+- replay、outbox retry、backup restore 必须幂等。
+- 启动恢复不能一次性加载全量 WAL、records、roots、global leaves、STH、anchors 或 backup entries。
+- 修改 fsync、checkpoint、segment cleanup、repair 或 restore 逻辑时，PR 必须说明崩溃窗口和恢复语义。
 
-### 确定性与可验证性
+#### 可扩展路径
 
-- Proof、receipt、STH、anchor result、backup manifest 等可信对象必须使用确定性编码和稳定字段顺序。
-- hash 输入必须在代码中有单一入口，禁止不同模块临时拼接各自版本的 hash payload。
-- 验证器必须独立复算，而不是信任服务端返回的等级、状态或摘要文本。
-- 错误信息可以友好，但不能吞掉验证失败的具体原因；安全相关失败不得降级成成功或 unknown。
-- 测试要覆盖“篡改后失败”，不只覆盖 happy path。
+- 生产路径默认按 Pebble proofstore 设计；file proofstore 只承诺开发和小规模演示。
+- 列表、pending scan、anchor upgrade、backup export/restore、global proof 生成必须优先使用 cursor/range/status index。
+- HTTP、CLI、SDK、desktop 主路径中不要重新引入全量扫描、全量排序或全量内存聚合。
+- Global Log proof 应读取必要 node/tile/range；不要为单个 proof 重建整棵树。
 
-### 持久化与恢复
+#### 接口一致性
 
-- WAL accepted、batch committed、global log appended、anchor published 是不同耐久边界，代码不能把它们混成一个状态。
-- 启动恢复必须是幂等的；重复 replay、重复 outbox 处理、重复 restore 不能产生重复 leaf 或改变已有 proof。
-- 恢复路径禁止为了方便一次性加载全部 WAL、roots、manifests、global leaves、records 或 backup entries。
-- group commit、checkpoint、segment cleanup 的改动必须说明崩溃窗口和恢复语义。
-- 任何“修复损坏数据”的逻辑都必须保守，能隔离坏记录时不要扩大损坏范围。
+- HTTP 和 gRPC 只是 transport 差异，不能改变 proof object 语义。
+- Go SDK 是客户端复用服务能力的主入口；桌面客户端不应重新扩散手写 HTTP 语义。
+- Wails 暴露 DTO 不使用 Go-only 类型；时间、大小、状态字段要有明确单位和稳定编码。
+- CLI exit behavior、HTTP status、gRPC error 和 SDK error 应能被自动化脚本可靠判断。
 
-### 可扩展数据路径
+#### 桌面客户端
 
-- 面向生产的路径默认按 Pebble proofstore 设计；file proofstore 只保证开发和小规模演示语义。
-- 列表、扫描、pending 查询、anchor upgrade、backup export/restore 必须优先使用 cursor/range/status index。
-- 不允许在 HTTP/CLI/desktop 主路径中重新引入全量扫描、全量排序或全量内存聚合。
-- Global Log proof 生成应读取必要 node/tile/range；不能为了生成单个 proof 重建整棵树。
-- 大规模路径新增 API 时，必须同时考虑 limit、cursor、direction、错误中断和可恢复性。
+- 本地 records 使用索引化存储，不退回单 JSON 全量读写。
+- 列表、搜索、详情、批量刷新按需加载，面向十万级本机记录保持可用。
+- `.sproof` 是主导出入口；分步 proof 文件保留为高级功能。
+- UI 改动需要考虑小窗口、长文件名、长 hash、加载中、失败状态和离线验证路径。
 
-### 并发与后台任务
+### Issue 和 PR 要求
 
-- batch commit、global append、STH anchor、OTS upgrade、backup/restore 应保持解耦；慢外部服务不能拖死 ingest 或 batch worker。
-- outbox worker 必须记录 attempts、last_error、next_attempt_at，并避免无界重试扫全表。
-- goroutine 必须有清晰的 context/lifecycle；服务关闭时要能停止、flush 或明确放弃非关键工作。
-- 共享状态优先通过持久化状态机或单一 owner goroutine 管理，避免跨 worker 隐式共享可变状态。
+Issue 应包含：
 
-### 公共接口
+- 背景和真实问题。
+- 目标和非目标。
+- 影响的架构边界。
+- 安全、兼容性、迁移或恢复影响。
+- 验收标准和测试计划。
 
-- HTTP/CLI/桌面客户端的同名概念必须返回同一类事实，不允许同一证明等级在不同入口中语义不同。
-- 新增公开字段时优先使用明确单位和时间基准，例如 `*_unix_nano`；不要暴露 Go 专用类型到 Wails DTO。
-- 错误码、HTTP status、CLI exit behavior 要能被自动化脚本判断。
-- API 文档和 README 示例必须来自当前实现；不能提前写尚未落地的接口。
+PR 应包含：
 
-### 桌面客户端
+- 关联 Issue，例如 `Refs #99`、`Fixes #99` 或 `Closes #99`。
+- 变更摘要。
+- 测试结果。
+- 风险和回滚方式。
+- 如果未运行某些相关测试，说明原因和残余风险。
 
-- records 本地存储必须保持索引化；不要退回单 JSON 全量读写。
-- 列表、搜索、详情、批量刷新必须按需加载，不能让十万级本机记录卡死启动或渲染。
-- 客户端显示的证明等级应来自本地 proof artifact 或服务端可验证状态，不能只靠前端推断。
-- 导出功能优先维护 `.sproof` 主路径；分步文件保留为高级入口，二者编码结果必须可相互验证。
-- UI 改动需要检查小窗口、长文件名、长 hash、失败状态和加载中状态。
+不要在 PR 中删除风险字段，也不要用“本地能跑”替代 CI 失败分析。
 
-### 文档与示例
+### 质量门
 
-- 文档只能写当前实现；路线图、设计草稿和未落地功能不要进入 README 或贡献指南。
-- 命令示例必须可执行，或明确写出前置条件。
-- Windows 示例优先使用 PowerShell；跨平台差异需要单独说明。
-- 若实现与设计文档冲突，以实现为准先修 README/贡献文档，再开 Issue 处理设计文档。
-
-## 测试要求
-
-按变更范围选择测试。常规后端变更至少运行：
+根据变更范围选择测试。后端主路径通常需要：
 
 ```powershell
 go test ./...
-```
-
-涉及并发、WAL、proofstore、global log、anchor、backup、HTTP 服务时，补充：
-
-```powershell
 go test -race ./...
 go test -tags=integration ./...
 go test -tags=e2e ./...
 ```
 
-涉及桌面客户端 Go 层：
+桌面客户端相关变更通常需要：
 
 ```powershell
 cd clients/desktop
 go test ./...
 go test -race ./...
-```
-
-涉及桌面前端：
-
-```powershell
-cd clients/desktop/frontend
+cd frontend
 npm run build
 ```
 
-涉及完整桌面包：
+完整桌面安装包变更需要额外验证：
 
 ```powershell
 cd clients/desktop
-wails build
+wails build -clean -nsis
 ```
 
-## CI 质量门
+CI 当前覆盖 repository hygiene、backend unit/race/integration/e2e、desktop Go tests 和 desktop frontend build。CI 失败时先定位差异，再决定修复、拆分或记录残余风险。
 
-Pull Request 会运行 `.github/workflows/ci.yml`。当前 CI 覆盖：
+### 文档边界
 
-- Repository hygiene：检查 whitespace，并防止 `doc/` / `docs/` 本地草稿目录被提交。
-- Backend unit tests：根模块依赖校验、`go mod tidy` 检查和 `go test ./...`。
-- Backend race tests：`go test -race ./...`。
-- Backend integration tests：`go test -count=1 -tags=integration ./...`。
-- Backend e2e tests：`go test -count=1 -tags=e2e ./...`。
-- Desktop Go tests：`clients/desktop` 依赖校验、tidy 检查和 Go 测试。
-- Desktop frontend build：`npm ci` 和 `npm run build`。
+- `README.md` 和 `README.zh-CN.md` 是用户入口，只写当前已经实现的系统能力。
+- `CONTRIBUTING.md` 维护贡献流程、架构边界和质量门。
+- `formats/` 记录稳定公开文件格式，例如 `.sproof`。
+- `configs/` 中的配置示例应与真实实现保持一致。
+- `doc/` 和 `docs/` 是本地草稿目录，不提交到仓库。
 
-CI 失败时不要用“本地能跑”直接覆盖。先定位 CI 与本地差异：Go/Node 版本、Linux/Windows 路径差异、race 暴露的并发问题、integration/e2e 的时序问题、或 npm lockfile 不一致。确实无法在本轮修复时，必须在 PR 中写明原因、残余风险和后续 Issue。
+### 安全、依赖和许可证
 
-如果某个测试因本机工具链、网络或外部服务不可用而无法运行，必须在 Issue 或 PR 中写明原因、已运行的替代检查和残余风险。
+- 不提交真实密钥、token、生产配置、本地数据库、`.tdbackup`、`.sproof` 样本中的敏感内容或构建产物。
+- 新依赖必须说明用途、许可证兼容性和供应链风险。
+- TrustDB 使用 AGPL-3.0-only；提交贡献即表示贡献按该许可证发布。
+- 安全问题优先私下报告给维护者，不要在公开 Issue 中泄露可利用细节。
 
-## 文档要求
+### 维护者合并检查
 
-需要同步更新文档的情况：
+合并前确认：
 
-- 新增或修改 CLI 命令、参数、配置项、环境变量。
-- 新增或修改 HTTP API。
-- 改变 L1-L5 证明语义。
-- 改变 `.tdproof`、`.tdgproof`、`.tdanchor-result`、`.sproof`、`.tdbackup` 格式。
-- 改变默认存储、WAL、anchor、backup 或桌面客户端行为。
-- 新增运维前置条件或安全注意事项。
+- Issue 和 PR 范围一致。
+- CI 已通过，或残余风险被明确记录并被维护者接受。
+- 证明语义、持久化边界和大规模路径没有退化。
+- 文档只描述当前实现。
+- 没有提交本地数据、密钥、构建产物或草稿文档。
+- CODEOWNERS review 要求已满足。
 
-仓库当前提交的主入口文档是：
+---
 
-- `README.md`：用户入口、当前功能、架构、快速向导。
-- `CONTRIBUTING.md`：贡献流程。
-- `clients/desktop/README.md`：桌面客户端说明。
-- `configs/*.yaml`：配置示例。
+## English Version
 
-`doc/` 和 `docs/` 当前作为本地设计/运维草稿目录被忽略，不作为默认提交内容。若某个 Issue 明确要求发布正式文档，需要先在 Issue 中说明目标路径和发布范围。
+### Contribution Principles
 
-## PR 要求
+- Issue first: every feature, bug fix, refactor, documentation release, or behavior change starts with a GitHub Issue that states context, goals, non-goals, risks, and acceptance criteria.
+- Small pull requests: one PR solves one Issue. Do not mix unrelated formatting, experiments, local data, or opportunistic refactors.
+- Current implementation only: README files, user-facing docs, and this guide must describe implemented behavior, not roadmap items.
+- Tests protect semantics: changes touching proofs, storage, recovery, APIs, SDKs, or the desktop client must test semantic boundaries and failure paths, not only happy paths.
+- Review before merge: `main` is protected by CODEOWNERS and branch protection. CI and maintainer review are required before merge.
+- Security by default: private keys, production configs, local databases, backup bundles, build artifacts, and deployment state must not be committed.
 
-提交 PR 前，请确认：
+### Repository Architecture Map
 
-- PR 标题说明变更目的。
-- PR 描述关联 Issue，例如 `Refs #2` 或 `Fixes #2`。
-- PR 描述包含变更摘要、测试结果、风险和回滚方式。
-- 只包含当前 Issue 范围内的文件。
-- 所有用户可见行为变化都更新了 README、配置示例或相关说明。
-- 新增功能有测试，修复 Bug 有回归测试或明确说明无法自动化的原因。
+TrustDB is currently a single-node system, but the implementation is split by trust and durability boundaries. Before changing code, identify which boundary you are touching.
 
-仓库已经提供 `.github/pull_request_template.md`。提交 PR 时保留模板中的证明语义、存储恢复、规模路径和验证清单；不相关的检查可以标注未运行原因，但不要删除风险字段。
+```text
+cmd/trustdb
+  CLI entrypoint and server wiring
 
-## 安全与密钥
+internal/model
+  Canonical proof, receipt, STH, anchor, backup, and API data models
 
-- 不要提交真实私钥、注册表密钥、服务器密钥、`.env` 或生产配置。
-- 示例密钥也不要放进仓库，除非 Issue 明确要求测试 fixture，且文件名、路径、用途都表明它不可用于生产。
-- 对外部 anchor、OpenTimestamps、远程服务调用的改动，需要说明失败、超时、重试和降级行为。
-- 任何会影响证明可信边界的改动，都要在 Issue/PR 中单独标出。
+internal/cborx + internal/trustcrypto
+  Deterministic CBOR encoding and cryptographic signing/hash utilities
 
-## 许可证
+internal/claim + internal/receipt + internal/verify + internal/prooflevel
+  Claim construction, accepted receipts, local verification, and L1-L5 semantics
 
-TrustDB 使用 AGPL-3.0-only。提交代码即表示你同意你的贡献按仓库许可证发布。
+internal/ingest + internal/wal
+  Bounded ingest queue, accepted-write durability, WAL replay, fsync policy, checkpoints
 
-如果引入第三方依赖或资产，需要确认其许可证与 AGPL-3.0-only 兼容，并在 PR 中说明来源和用途。
+internal/batch + internal/merkle
+  Batch construction, Merkle roots, proof bundles, committed root metadata
 
-## 发布与部署边界
+internal/globallog
+  Global Transparency Log, STH generation, inclusion proofs, consistency proofs, tiles/frontier state
 
-普通 PR 不直接部署生产服务，也不修改本机或远程运行数据。部署类任务必须有单独 Issue，并在 Issue 中写明：
+internal/anchor
+  STH/global-root anchor outbox, sinks, retry/upgrade behavior, OpenTimestamps integration
 
-- 部署目标
-- 备份方式
-- 回滚方式
-- 验证命令
-- 影响窗口
+internal/proofstore + internal/proofstore/pebble
+  File and Pebble proofstore implementations, indexes, cursor/range access, persisted artifacts
 
-## 维护者合并前检查
+internal/httpapi + internal/grpcapi
+  Public service surfaces for HTTP and gRPC, preserving shared proof object semantics
 
-- Issue 是否清楚且与 PR 对应。
-- 变更是否保持证明语义一致。
-- 存储和恢复路径是否避免重新引入全量扫描/全量加载。
-- 文档是否只写当前实现。
-- 测试是否覆盖主要风险。
-- 是否有敏感文件或本地数据被误提交。
+internal/backup + internal/sproof
+  Portable backup/restore and single-file proof exchange formats
+
+sdk
+  Public Go SDK used by automation and the desktop client transport layer
+
+clients/desktop
+  Wails + Vue desktop app, local identity, server settings, Pebble-backed local record index, proof export/verify
+
+configs + formats + scripts
+  Supported configuration profiles, stable public file-format docs, and release/development helpers
+```
+
+### Data Flow and Trust Boundaries
+
+```text
+File -> SignedClaim -> AcceptedReceipt -> ProofBundle -> GlobalLogProof -> STHAnchorResult
+       L1             L2                L3             L4              L5
+```
+
+- L1: the client signs a claim containing file hash and metadata.
+- L2: the server validates the claim and accepts it within the WAL durability boundary.
+- L3: the batch worker commits accepted records into a Merkle batch and emits a `ProofBundle`.
+- L4: the batch root is included in the Global Transparency Log and can be proven against an STH.
+- L5: the corresponding STH/global root is anchored by an external anchor sink.
+
+Important boundaries:
+
+- L4 is not external anchoring. It only proves inclusion in the global log.
+- L5 anchors only STH/global roots. Do not reintroduce direct per-batch root anchoring.
+- `.sproof` is the primary exchange format. `.tdproof`, `.tdgproof`, and `.tdanchor-result` are advanced split artifacts.
+- Verifiers must recompute proofs, hashes, and signatures independently. They must not trust server-provided level labels.
+
+### Change Areas and Architectural Responsibilities
+
+| Area | Main responsibility | Typical checks |
+| --- | --- | --- |
+| Proof/model/encoding | Deterministic CBOR, hash/signature inputs, compatibility boundaries, tamper-failure tests | `go test ./...`, format and verifier regression tests |
+| WAL/ingest/replay | Durable boundary, idempotent replay, checkpoints, crash windows, memory usage | unit, race, integration |
+| Batch/global log | Stable Merkle roots, recoverable proofs, consistency proofs, no O(N) hot paths | unit, benchmark, integration/e2e |
+| Proofstore/Pebble | Key schema, secondary indexes, cursor/range APIs, file backend downgrade semantics | proofstore tests, large-path tests |
+| Anchor/OTS | STH-only semantics, outbox retry, `next_attempt_at`, external failure isolation | unit, fake-sink integration |
+| HTTP/gRPC/SDK | Transport parity, scriptable errors, shared CBOR payload semantics | unit, e2e, SDK tests |
+| Desktop client | Go SDK transport, Pebble-backed local index, paginated/virtualized lists, `.sproof` main path | desktop Go tests, frontend build, manual smoke |
+| Backup/restore | Streaming entries, entry hash, resume checkpoints, idempotent repeated restore | backup tests, interruption tests |
+| Documentation | Implemented behavior only, bilingual entry points, verifiable commands and paths | `git diff --check` |
+
+### Architectural Invariants
+
+#### Proof Semantics
+
+- L1-L5 meanings must stay consistent across CLI, HTTP, gRPC, SDK, desktop UI, and verifiers.
+- Changes to proof object fields, encoding, hash inputs, or signature inputs must state compatibility boundaries.
+- Security failures must not be downgraded to success, unknown, or a UI-only warning.
+- Regression tests should cover tampered artifacts, wrong public keys, wrong batch roots, wrong STHs, and missing anchors.
+
+#### Durability and Recovery
+
+- WAL accepted, batch committed, global log appended, and anchor published are separate durability boundaries.
+- Replay, outbox retry, and backup restore must be idempotent.
+- Startup recovery must not load all WAL records, records, roots, global leaves, STHs, anchors, or backup entries into memory.
+- PRs changing fsync, checkpoints, segment cleanup, repair, or restore logic must explain crash windows and recovery semantics.
+
+#### Scalable Paths
+
+- Production paths are designed around the Pebble proofstore. The file proofstore is for development and small demos.
+- Lists, pending scans, anchor upgrades, backup export/restore, and global proof generation should use cursor/range/status indexes.
+- Do not reintroduce full scans, global sorting, or all-record in-memory aggregation into HTTP, CLI, SDK, or desktop hot paths.
+- Global Log proofs should read necessary nodes, tiles, or ranges. Do not rebuild the whole tree for a single proof.
+
+#### Interface Consistency
+
+- HTTP and gRPC are transport choices; they must not change proof object semantics.
+- The Go SDK is the primary reusable client surface. The desktop client should not spread independent handwritten HTTP semantics.
+- Wails DTOs must avoid Go-only types. Time, size, and state fields need explicit units and stable encoding.
+- CLI exit behavior, HTTP status, gRPC errors, and SDK errors should be reliable for automation.
+
+#### Desktop Client
+
+- Local records must remain indexed. Do not return to one large JSON file for all records.
+- Lists, search, details, and batch refresh should load on demand and remain usable with hundreds of thousands of local records.
+- `.sproof` is the primary export path. Split proof artifacts remain advanced functionality.
+- UI changes should account for narrow windows, long filenames, long hashes, loading states, failure states, and offline verification.
+
+### Issue and Pull Request Expectations
+
+Issues should include:
+
+- Context and the real problem.
+- Goals and non-goals.
+- Affected architecture boundaries.
+- Security, compatibility, migration, or recovery impact.
+- Acceptance criteria and test plan.
+
+Pull requests should include:
+
+- Linked Issue, such as `Refs #99`, `Fixes #99`, or `Closes #99`.
+- Change summary.
+- Test results.
+- Risks and rollback notes.
+- If relevant checks were not run, explain why and state residual risk.
+
+Do not delete risk fields from PR templates, and do not use “works locally” as a substitute for CI failure analysis.
+
+### Quality Gates
+
+Choose checks based on the touched boundary. Backend hot-path changes usually require:
+
+```powershell
+go test ./...
+go test -race ./...
+go test -tags=integration ./...
+go test -tags=e2e ./...
+```
+
+Desktop client changes usually require:
+
+```powershell
+cd clients/desktop
+go test ./...
+go test -race ./...
+cd frontend
+npm run build
+```
+
+Desktop installer changes also require:
+
+```powershell
+cd clients/desktop
+wails build -clean -nsis
+```
+
+CI currently runs repository hygiene, backend unit/race/integration/e2e tests, desktop Go tests, and the desktop frontend build. When CI fails, identify the difference first, then fix, split, or document the residual risk.
+
+### Documentation Boundaries
+
+- `README.md` and `README.zh-CN.md` are user entry points and must describe only implemented behavior.
+- `CONTRIBUTING.md` maintains contribution workflow, architecture boundaries, and quality gates.
+- `formats/` documents stable public file formats, such as `.sproof`.
+- `configs/` examples must stay aligned with real implementation.
+- `doc/` and `docs/` are local draft directories and must not be committed.
+
+### Security, Dependencies, and License
+
+- Do not commit real keys, tokens, production configs, local databases, `.tdbackup` files, sensitive `.sproof` samples, or build artifacts.
+- New dependencies must explain purpose, license compatibility, and supply-chain risk.
+- TrustDB is licensed under AGPL-3.0-only. By contributing, you agree that your contribution is released under that license.
+- Report security issues privately to maintainers first. Do not disclose exploitable details in public Issues.
+
+### Maintainer Merge Checklist
+
+Before merging, confirm that:
+
+- Issue and PR scope match.
+- CI passed, or residual risk is explicitly documented and accepted.
+- Proof semantics, durability boundaries, and scalable paths did not regress.
+- Documentation describes current implementation only.
+- No local data, secrets, build artifacts, or draft docs are committed.
+- CODEOWNERS review requirements are satisfied.


### PR DESCRIPTION
## Summary
- 将 `CONTRIBUTING.md` 重写为中英双文
- 增加 TrustDB 当前代码架构地图和数据流/可信边界说明
- 将贡献指南重点从基础 Git/工具知识转向证明语义、持久化、可扩展路径、接口一致性和维护者检查

## Validation
- `git diff --check`

Closes #99