### PR TITLE
feat: complete paginated record and global listing APIs

### DIFF
--- a/clients/desktop/client.go
+++ b/clients/desktop/client.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/ryan-wong-coder/trustdb/internal/model"
-	"github.com/ryan-wong-coder/trustdb/internal/prooflevel"
 	"github.com/ryan-wong-coder/trustdb/sdk"
 )
 
@@ -189,6 +188,7 @@ func (c *serverClient) listRecordIndexes(ctx context.Context, opts RecordPageOpt
 		BatchID:        opts.BatchID,
 		TenantID:       opts.TenantID,
 		ClientID:       opts.ClientID,
+		ProofLevel:     opts.Level,
 		Query:          query,
 		ContentHashHex: contentHash,
 	})
@@ -229,10 +229,9 @@ func looksLikeSHA256Hex(query string) bool {
 }
 
 func localRecordFromIndex(idx model.RecordIndex) LocalRecord {
-	proofLevel := prooflevel.L2
+	proofLevel := model.RecordIndexProofLevel(idx)
 	var committed *model.CommittedReceipt
 	if idx.BatchID != "" {
-		proofLevel = prooflevel.L3
 		committed = &model.CommittedReceipt{
 			SchemaVersion: model.SchemaCommittedReceipt,
 			RecordID:      idx.RecordID,
@@ -258,7 +257,7 @@ func localRecordFromIndex(idx model.RecordIndex) LocalRecord {
 		TenantID:         idx.TenantID,
 		ClientID:         idx.ClientID,
 		KeyID:            idx.KeyID,
-		ProofLevel:       proofLevel.String(),
+		ProofLevel:       proofLevel,
 		BatchID:          idx.BatchID,
 		CommittedReceipt: committed,
 	}

--- a/clients/desktop/client_test.go
+++ b/clients/desktop/client_test.go
@@ -150,6 +150,29 @@ func TestHTTPClientListRecordIndexesSendsServerSearchFilters(t *testing.T) {
 	}
 }
 
+func TestHTTPClientListRecordIndexesSendsLevelFilter(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/records" {
+			t.Fatalf("path = %s, want /v1/records", r.URL.Path)
+		}
+		if r.URL.Query().Get("level") != "L4" {
+			t.Fatalf("query = %s", r.URL.RawQuery)
+		}
+		_ = json.NewEncoder(w).Encode(recordPageResponse{Limit: 50, Direction: "desc"})
+	}))
+	defer srv.Close()
+
+	client, err := newServerClient(serverTransportHTTP, srv.URL)
+	if err != nil {
+		t.Fatalf("newServerClient: %v", err)
+	}
+	if _, err := client.listRecordIndexes(context.Background(), RecordPageOptions{Level: "L4"}); err != nil {
+		t.Fatalf("listRecordIndexes level: %v", err)
+	}
+}
+
 func TestNormalizeGRPCTargetStripsHTTPStyleURL(t *testing.T) {
 	t.Parallel()
 

--- a/clients/desktop/frontend/src/pages/Records.vue
+++ b/clients/desktop/frontend/src/pages/Records.vue
@@ -298,9 +298,6 @@ async function upgradeOts(r: LocalRecord) {
         <span class="rounded-full border border-accent/20 bg-accent/10 px-2.5 py-1 text-accent">
           {{ source === 'server' ? '服务端分页 · /v1/records' : '本地缓存' }}
         </span>
-        <span v-if="levelFilter && source === 'local'">
-          证明等级筛选目前走本地缓存；服务端 records index 不做 L4/L5 全量扫描。
-        </span>
         <span v-if="listError" class="text-warn">
           {{ listError }}
         </span>

--- a/clients/desktop/frontend/src/stores/records.ts
+++ b/clients/desktop/frontend/src/stores/records.ts
@@ -26,8 +26,7 @@ export const useRecords = defineStore('records', () => {
   const pending = computed(() => records.value.filter((r) => r.proof_level !== 'L5'))
   const canUseRemote = computed(() => source.value === 'server')
 
-  function canRemoteQuery(_query: string, level: string) {
-    if (level) return false
+  function canRemoteQuery(_query: string, _level: string) {
     return true
   }
 

--- a/internal/anchor/api.go
+++ b/internal/anchor/api.go
@@ -26,3 +26,7 @@ func (a *API) AnchorResult(ctx context.Context, treeSize uint64) (model.STHAncho
 func (a *API) AnchorStatus(ctx context.Context, treeSize uint64) (model.STHAnchorOutboxItem, bool, error) {
 	return a.Store.GetSTHAnchorOutboxItem(ctx, treeSize)
 }
+
+func (a *API) Anchors(ctx context.Context, opts model.AnchorListOptions) ([]model.STHAnchorOutboxItem, error) {
+	return a.Store.ListSTHAnchorsPage(ctx, opts)
+}

--- a/internal/batch/service.go
+++ b/internal/batch/service.go
@@ -18,11 +18,13 @@ type Engine interface {
 type Store interface {
 	PutBundle(context.Context, model.ProofBundle) error
 	GetBundle(context.Context, string) (model.ProofBundle, error)
+	PutRecordIndex(context.Context, model.RecordIndex) error
 	GetRecordIndex(context.Context, string) (model.RecordIndex, bool, error)
 	ListRecordIndexes(context.Context, model.RecordListOptions) ([]model.RecordIndex, error)
 	PutRoot(context.Context, model.BatchRoot) error
 	ListRoots(context.Context, int) ([]model.BatchRoot, error)
 	ListRootsAfter(context.Context, int64, int) ([]model.BatchRoot, error)
+	ListRootsPage(context.Context, model.RootListOptions) ([]model.BatchRoot, error)
 	LatestRoot(context.Context) (model.BatchRoot, error)
 	PutManifest(context.Context, model.BatchManifest) error
 	GetManifest(context.Context, string) (model.BatchManifest, error)
@@ -191,6 +193,13 @@ func (s *Service) RootsAfter(ctx context.Context, afterClosedAtUnixN int64, limi
 		return nil, trusterr.New(trusterr.CodeFailedPrecondition, "proof store is not configured")
 	}
 	return s.store.ListRootsAfter(ctx, afterClosedAtUnixN, limit)
+}
+
+func (s *Service) RootsPage(ctx context.Context, opts model.RootListOptions) ([]model.BatchRoot, error) {
+	if s.store == nil {
+		return nil, trusterr.New(trusterr.CodeFailedPrecondition, "proof store is not configured")
+	}
+	return s.store.ListRootsPage(ctx, opts)
 }
 
 func (s *Service) LatestRoot(ctx context.Context) (model.BatchRoot, error) {

--- a/internal/globallog/service.go
+++ b/internal/globallog/service.go
@@ -28,12 +28,14 @@ type Store interface {
 	GetGlobalLeafByBatchID(context.Context, string) (model.GlobalLogLeaf, bool, error)
 	ListGlobalLeaves(context.Context) ([]model.GlobalLogLeaf, error)
 	ListGlobalLeavesRange(context.Context, uint64, int) ([]model.GlobalLogLeaf, error)
+	ListGlobalLeavesPage(context.Context, model.GlobalLeafListOptions) ([]model.GlobalLogLeaf, error)
 	PutGlobalLogNode(context.Context, model.GlobalLogNode) error
 	GetGlobalLogNode(context.Context, uint64, uint64) (model.GlobalLogNode, bool, error)
 	PutGlobalLogState(context.Context, model.GlobalLogState) error
 	GetGlobalLogState(context.Context) (model.GlobalLogState, bool, error)
 	PutSignedTreeHead(context.Context, model.SignedTreeHead) error
 	GetSignedTreeHead(context.Context, uint64) (model.SignedTreeHead, bool, error)
+	ListSignedTreeHeadsPage(context.Context, model.TreeHeadListOptions) ([]model.SignedTreeHead, error)
 	LatestSignedTreeHead(context.Context) (model.SignedTreeHead, bool, error)
 	PutGlobalLogTile(context.Context, model.GlobalLogTile) error
 	ListGlobalLogTiles(context.Context) ([]model.GlobalLogTile, error)
@@ -170,6 +172,14 @@ func (s *Service) LatestSTH(ctx context.Context) (model.SignedTreeHead, bool, er
 
 func (s *Service) STH(ctx context.Context, treeSize uint64) (model.SignedTreeHead, bool, error) {
 	return s.store.GetSignedTreeHead(ctx, treeSize)
+}
+
+func (s *Service) ListSTHs(ctx context.Context, opts model.TreeHeadListOptions) ([]model.SignedTreeHead, error) {
+	return s.store.ListSignedTreeHeadsPage(ctx, opts)
+}
+
+func (s *Service) ListLeaves(ctx context.Context, opts model.GlobalLeafListOptions) ([]model.GlobalLogLeaf, error) {
+	return s.store.ListGlobalLeavesPage(ctx, opts)
 }
 
 func (s *Service) InclusionProof(ctx context.Context, batchID string, treeSize uint64) (model.GlobalLogProof, error) {

--- a/internal/grpcapi/server.go
+++ b/internal/grpcapi/server.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"strings"
 
 	"github.com/ryan-wong-coder/trustdb/internal/httpapi"
@@ -120,30 +119,36 @@ func (s *Server) ListRoots(ctx context.Context, req *ListRootsRequest) (*ListRoo
 	if s.Batch == nil {
 		return nil, toStatusError(trusterr.New(trusterr.CodeFailedPrecondition, "batch service is not configured"))
 	}
-	limit := req.Limit
-	if limit <= 0 {
-		limit = 100
+	direction, err := parseDirection(req.Direction)
+	if err != nil {
+		return nil, toStatusError(err)
 	}
-	if limit > 1000 {
+	opts := model.RootListOptions{Limit: req.Limit, Direction: direction}
+	if opts.Limit <= 0 {
+		opts.Limit = 100
+	}
+	if opts.Limit > 1000 {
 		return nil, toStatusError(trusterr.New(trusterr.CodeInvalidArgument, "limit must be between 1 and 1000"))
 	}
-	var (
-		roots []model.BatchRoot
-		err   error
-	)
-	if req.After > 0 {
-		roots, err = s.Batch.RootsAfter(ctx, req.After, limit)
-	} else {
-		roots, err = s.Batch.Roots(ctx, limit)
+	if req.Cursor != "" {
+		cursor, err := decodeRootCursor(req.Cursor)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+		opts.AfterClosedAtUnixN = cursor.ClosedAtUnixN
+		opts.AfterBatchID = cursor.BatchID
+	} else if req.After > 0 {
+		opts.AfterClosedAtUnixN = req.After
 	}
+	roots, err := s.Batch.RootsPage(ctx, opts)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
 	next := ""
-	if req.After > 0 && len(roots) == limit {
-		next = strconv.FormatInt(roots[len(roots)-1].ClosedAtUnixN, 10)
+	if len(roots) == opts.Limit {
+		next = encodeRootCursor(roots[len(roots)-1])
 	}
-	return &ListRootsResponse{Roots: roots, Limit: limit, NextCursor: next}, nil
+	return &ListRootsResponse{Roots: roots, Limit: opts.Limit, Direction: opts.Direction, NextCursor: next}, nil
 }
 
 func (s *Server) LatestRoot(ctx context.Context, _ *LatestRootRequest) (*LatestRootResponse, error) {
@@ -155,6 +160,39 @@ func (s *Server) LatestRoot(ctx context.Context, _ *LatestRootRequest) (*LatestR
 		return nil, toStatusError(err)
 	}
 	return &LatestRootResponse{Root: root}, nil
+}
+
+func (s *Server) ListSTHs(ctx context.Context, req *ListSTHsRequest) (*ListSTHsResponse, error) {
+	if s.Global == nil {
+		return nil, toStatusError(trusterr.New(trusterr.CodeFailedPrecondition, "global log service is not configured"))
+	}
+	direction, err := parseDirection(req.Direction)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	opts := model.TreeHeadListOptions{Limit: req.Limit, Direction: direction}
+	if opts.Limit <= 0 {
+		opts.Limit = 100
+	}
+	if opts.Limit > 1000 {
+		return nil, toStatusError(trusterr.New(trusterr.CodeInvalidArgument, "limit must be between 1 and 1000"))
+	}
+	if req.Cursor != "" {
+		cursor, err := decodeUint64Cursor(req.Cursor)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+		opts.AfterTreeSize = cursor.Value
+	}
+	sths, err := s.Global.ListSTHs(ctx, opts)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	next := ""
+	if len(sths) == opts.Limit {
+		next = encodeUint64Cursor(sths[len(sths)-1].TreeSize)
+	}
+	return &ListSTHsResponse{STHs: sths, Limit: opts.Limit, Direction: opts.Direction, NextCursor: next}, nil
 }
 
 func (s *Server) LatestSTH(ctx context.Context, _ *LatestSTHRequest) (*LatestSTHResponse, error) {
@@ -199,6 +237,39 @@ func (s *Server) GetGlobalProof(ctx context.Context, req *GetGlobalProofRequest)
 	return &GetGlobalProofResponse{Proof: proof}, nil
 }
 
+func (s *Server) ListGlobalLeaves(ctx context.Context, req *ListGlobalLeavesRequest) (*ListGlobalLeavesResponse, error) {
+	if s.Global == nil {
+		return nil, toStatusError(trusterr.New(trusterr.CodeFailedPrecondition, "global log service is not configured"))
+	}
+	direction, err := parseDirection(req.Direction)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	opts := model.GlobalLeafListOptions{Limit: req.Limit, Direction: direction}
+	if opts.Limit <= 0 {
+		opts.Limit = 100
+	}
+	if opts.Limit > 1000 {
+		return nil, toStatusError(trusterr.New(trusterr.CodeInvalidArgument, "limit must be between 1 and 1000"))
+	}
+	if req.Cursor != "" {
+		cursor, err := decodeUint64Cursor(req.Cursor)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+		opts.AfterLeafIndex = cursor.Value
+	}
+	leaves, err := s.Global.ListLeaves(ctx, opts)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	next := ""
+	if len(leaves) == opts.Limit {
+		next = encodeUint64Cursor(leaves[len(leaves)-1].LeafIndex)
+	}
+	return &ListGlobalLeavesResponse{Leaves: leaves, Limit: opts.Limit, Direction: opts.Direction, NextCursor: next}, nil
+}
+
 func (s *Server) GetAnchor(ctx context.Context, req *GetAnchorRequest) (*GetAnchorResponse, error) {
 	if s.Anchors == nil {
 		return nil, toStatusError(trusterr.New(trusterr.CodeFailedPrecondition, "anchor service is not configured"))
@@ -217,20 +288,48 @@ func (s *Server) GetAnchor(ctx context.Context, req *GetAnchorRequest) (*GetAnch
 	if !itemOK && !resultOK {
 		return nil, toStatusError(trusterr.New(trusterr.CodeNotFound, "anchor not found for STH"))
 	}
-	resp := &GetAnchorResponse{TreeSize: req.TreeSize, ProofLevel: prooflevel.L5.String()}
-	switch {
-	case resultOK:
-		resp.Status = model.AnchorStatePublished
-		resp.Result = &result
-	case itemOK:
-		resp.Status = item.Status
-	default:
-		resp.Status = "unknown"
+	return anchorEnvelopeResponse(req.TreeSize, item, itemOK, result, resultOK), nil
+}
+
+func (s *Server) ListAnchors(ctx context.Context, req *ListAnchorsRequest) (*ListAnchorsResponse, error) {
+	if s.Anchors == nil {
+		return nil, toStatusError(trusterr.New(trusterr.CodeFailedPrecondition, "anchor service is not configured"))
 	}
-	if itemOK {
-		resp.Outbox = &item
+	direction, err := parseDirection(req.Direction)
+	if err != nil {
+		return nil, toStatusError(err)
 	}
-	return resp, nil
+	opts := model.AnchorListOptions{Limit: req.Limit, Direction: direction}
+	if opts.Limit <= 0 {
+		opts.Limit = 100
+	}
+	if opts.Limit > 1000 {
+		return nil, toStatusError(trusterr.New(trusterr.CodeInvalidArgument, "limit must be between 1 and 1000"))
+	}
+	if req.Cursor != "" {
+		cursor, err := decodeUint64Cursor(req.Cursor)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+		opts.AfterTreeSize = cursor.Value
+	}
+	items, err := s.Anchors.Anchors(ctx, opts)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	anchors := make([]GetAnchorResponse, 0, len(items))
+	for _, item := range items {
+		result, resultOK, err := s.Anchors.AnchorResult(ctx, item.TreeSize)
+		if err != nil {
+			return nil, toStatusError(err)
+		}
+		anchors = append(anchors, *anchorEnvelopeResponse(item.TreeSize, item, true, result, resultOK))
+	}
+	next := ""
+	if len(items) == opts.Limit {
+		next = encodeUint64Cursor(items[len(items)-1].TreeSize)
+	}
+	return &ListAnchorsResponse{Anchors: anchors, Limit: opts.Limit, Direction: opts.Direction, NextCursor: next}, nil
 }
 
 func (s *Server) Metrics(ctx context.Context, _ *MetricsRequest) (*MetricsResponse, error) {
@@ -268,9 +367,13 @@ func recordListOptions(req *ListRecordsRequest) (model.RecordListOptions, error)
 		BatchID:           req.BatchID,
 		TenantID:          req.TenantID,
 		ClientID:          req.ClientID,
+		ProofLevel:        model.NormalizedProofLevel(req.ProofLevel),
 		Query:             strings.TrimSpace(req.Query),
 		ReceivedFromUnixN: req.ReceivedFromUnixN,
 		ReceivedToUnixN:   req.ReceivedToUnixN,
+	}
+	if req.ProofLevel != "" && opts.ProofLevel == "" {
+		return model.RecordListOptions{}, trusterr.New(trusterr.CodeInvalidArgument, "level must be one of L1-L5")
 	}
 	if opts.BatchID == "" && strings.HasPrefix(strings.ToLower(opts.Query), "batch-") {
 		opts.BatchID = opts.Query
@@ -353,6 +456,83 @@ func decodeRecordCursor(raw string) (recordCursor, error) {
 		return recordCursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
 	}
 	return cursor, nil
+}
+
+type rootCursor struct {
+	ClosedAtUnixN int64  `json:"t"`
+	BatchID       string `json:"b"`
+}
+
+func encodeRootCursor(root model.BatchRoot) string {
+	data, err := json.Marshal(rootCursor{ClosedAtUnixN: root.ClosedAtUnixN, BatchID: root.BatchID})
+	if err != nil {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func decodeRootCursor(raw string) (rootCursor, error) {
+	data, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return rootCursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
+	}
+	var cursor rootCursor
+	if err := json.NewDecoder(bytes.NewReader(data)).Decode(&cursor); err != nil || cursor.BatchID == "" {
+		return rootCursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
+	}
+	return cursor, nil
+}
+
+type uint64Cursor struct {
+	Value uint64 `json:"v"`
+}
+
+func encodeUint64Cursor(value uint64) string {
+	data, err := json.Marshal(uint64Cursor{Value: value})
+	if err != nil {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func decodeUint64Cursor(raw string) (uint64Cursor, error) {
+	data, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return uint64Cursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
+	}
+	var cursor uint64Cursor
+	if err := json.NewDecoder(bytes.NewReader(data)).Decode(&cursor); err != nil {
+		return uint64Cursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
+	}
+	return cursor, nil
+}
+
+func parseDirection(raw string) (string, error) {
+	switch raw {
+	case "":
+		return model.RecordListDirectionDesc, nil
+	case model.RecordListDirectionAsc, model.RecordListDirectionDesc:
+		return raw, nil
+	default:
+		return "", trusterr.New(trusterr.CodeInvalidArgument, "direction must be asc or desc")
+	}
+}
+
+func anchorEnvelopeResponse(treeSize uint64, item model.STHAnchorOutboxItem, itemOK bool, result model.STHAnchorResult, resultOK bool) *GetAnchorResponse {
+	resp := &GetAnchorResponse{TreeSize: treeSize, ProofLevel: prooflevel.L5.String()}
+	switch {
+	case resultOK:
+		resp.Status = model.AnchorStatePublished
+		resp.Result = &result
+	case itemOK:
+		resp.Status = item.Status
+	default:
+		resp.Status = "unknown"
+	}
+	if itemOK {
+		resp.Outbox = &item
+	}
+	return resp
 }
 
 func toStatusError(err error) error {

--- a/internal/grpcapi/service_desc.go
+++ b/internal/grpcapi/service_desc.go
@@ -14,9 +14,12 @@ type TrustDBServiceServer interface {
 	GetProofBundle(context.Context, *GetProofBundleRequest) (*GetProofBundleResponse, error)
 	ListRoots(context.Context, *ListRootsRequest) (*ListRootsResponse, error)
 	LatestRoot(context.Context, *LatestRootRequest) (*LatestRootResponse, error)
+	ListSTHs(context.Context, *ListSTHsRequest) (*ListSTHsResponse, error)
 	LatestSTH(context.Context, *LatestSTHRequest) (*LatestSTHResponse, error)
 	GetSTH(context.Context, *GetSTHRequest) (*GetSTHResponse, error)
+	ListGlobalLeaves(context.Context, *ListGlobalLeavesRequest) (*ListGlobalLeavesResponse, error)
 	GetGlobalProof(context.Context, *GetGlobalProofRequest) (*GetGlobalProofResponse, error)
+	ListAnchors(context.Context, *ListAnchorsRequest) (*ListAnchorsResponse, error)
 	GetAnchor(context.Context, *GetAnchorRequest) (*GetAnchorResponse, error)
 	Metrics(context.Context, *MetricsRequest) (*MetricsResponse, error)
 }
@@ -36,9 +39,12 @@ var TrustDBService_ServiceDesc = grpc.ServiceDesc{
 		{MethodName: "GetProofBundle", Handler: _TrustDB_GetProofBundle_Handler},
 		{MethodName: "ListRoots", Handler: _TrustDB_ListRoots_Handler},
 		{MethodName: "LatestRoot", Handler: _TrustDB_LatestRoot_Handler},
+		{MethodName: "ListSTHs", Handler: _TrustDB_ListSTHs_Handler},
 		{MethodName: "LatestSTH", Handler: _TrustDB_LatestSTH_Handler},
 		{MethodName: "GetSTH", Handler: _TrustDB_GetSTH_Handler},
+		{MethodName: "ListGlobalLeaves", Handler: _TrustDB_ListGlobalLeaves_Handler},
 		{MethodName: "GetGlobalProof", Handler: _TrustDB_GetGlobalProof_Handler},
+		{MethodName: "ListAnchors", Handler: _TrustDB_ListAnchors_Handler},
 		{MethodName: "GetAnchor", Handler: _TrustDB_GetAnchor_Handler},
 		{MethodName: "Metrics", Handler: _TrustDB_Metrics_Handler},
 	},
@@ -110,6 +116,12 @@ func _TrustDB_LatestRoot_Handler(srv any, ctx context.Context, dec func(any) err
 	})
 }
 
+func _TrustDB_ListSTHs_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
+	return unaryHandler[ListSTHsRequest](srv, ctx, dec, interceptor, "ListSTHs", func(s TrustDBServiceServer, ctx context.Context, req *ListSTHsRequest) (any, error) {
+		return s.ListSTHs(ctx, req)
+	})
+}
+
 func _TrustDB_LatestSTH_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	return unaryHandler[LatestSTHRequest](srv, ctx, dec, interceptor, "LatestSTH", func(s TrustDBServiceServer, ctx context.Context, req *LatestSTHRequest) (any, error) {
 		return s.LatestSTH(ctx, req)
@@ -122,9 +134,21 @@ func _TrustDB_GetSTH_Handler(srv any, ctx context.Context, dec func(any) error, 
 	})
 }
 
+func _TrustDB_ListGlobalLeaves_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
+	return unaryHandler[ListGlobalLeavesRequest](srv, ctx, dec, interceptor, "ListGlobalLeaves", func(s TrustDBServiceServer, ctx context.Context, req *ListGlobalLeavesRequest) (any, error) {
+		return s.ListGlobalLeaves(ctx, req)
+	})
+}
+
 func _TrustDB_GetGlobalProof_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
 	return unaryHandler[GetGlobalProofRequest](srv, ctx, dec, interceptor, "GetGlobalProof", func(s TrustDBServiceServer, ctx context.Context, req *GetGlobalProofRequest) (any, error) {
 		return s.GetGlobalProof(ctx, req)
+	})
+}
+
+func _TrustDB_ListAnchors_Handler(srv any, ctx context.Context, dec func(any) error, interceptor grpc.UnaryServerInterceptor) (any, error) {
+	return unaryHandler[ListAnchorsRequest](srv, ctx, dec, interceptor, "ListAnchors", func(s TrustDBServiceServer, ctx context.Context, req *ListAnchorsRequest) (any, error) {
+		return s.ListAnchors(ctx, req)
 	})
 }
 

--- a/internal/grpcapi/types.go
+++ b/internal/grpcapi/types.go
@@ -7,18 +7,21 @@ const MaxMessageBytes = 16 << 20
 const ServiceName = "trustdb.v1.TrustDB"
 
 const (
-	FullMethodHealth         = "/" + ServiceName + "/Health"
-	FullMethodSubmitClaim    = "/" + ServiceName + "/SubmitClaim"
-	FullMethodGetRecord      = "/" + ServiceName + "/GetRecord"
-	FullMethodListRecords    = "/" + ServiceName + "/ListRecords"
-	FullMethodGetProofBundle = "/" + ServiceName + "/GetProofBundle"
-	FullMethodListRoots      = "/" + ServiceName + "/ListRoots"
-	FullMethodLatestRoot     = "/" + ServiceName + "/LatestRoot"
-	FullMethodLatestSTH      = "/" + ServiceName + "/LatestSTH"
-	FullMethodGetSTH         = "/" + ServiceName + "/GetSTH"
-	FullMethodGetGlobalProof = "/" + ServiceName + "/GetGlobalProof"
-	FullMethodGetAnchor      = "/" + ServiceName + "/GetAnchor"
-	FullMethodMetrics        = "/" + ServiceName + "/Metrics"
+	FullMethodHealth           = "/" + ServiceName + "/Health"
+	FullMethodSubmitClaim      = "/" + ServiceName + "/SubmitClaim"
+	FullMethodGetRecord        = "/" + ServiceName + "/GetRecord"
+	FullMethodListRecords      = "/" + ServiceName + "/ListRecords"
+	FullMethodGetProofBundle   = "/" + ServiceName + "/GetProofBundle"
+	FullMethodListRoots        = "/" + ServiceName + "/ListRoots"
+	FullMethodLatestRoot       = "/" + ServiceName + "/LatestRoot"
+	FullMethodListSTHs         = "/" + ServiceName + "/ListSTHs"
+	FullMethodLatestSTH        = "/" + ServiceName + "/LatestSTH"
+	FullMethodGetSTH           = "/" + ServiceName + "/GetSTH"
+	FullMethodListGlobalLeaves = "/" + ServiceName + "/ListGlobalLeaves"
+	FullMethodGetGlobalProof   = "/" + ServiceName + "/GetGlobalProof"
+	FullMethodListAnchors      = "/" + ServiceName + "/ListAnchors"
+	FullMethodGetAnchor        = "/" + ServiceName + "/GetAnchor"
+	FullMethodMetrics          = "/" + ServiceName + "/Metrics"
 )
 
 type HealthRequest struct{}
@@ -57,6 +60,7 @@ type ListRecordsRequest struct {
 	BatchID           string `cbor:"batch_id,omitempty" json:"batch_id,omitempty"`
 	TenantID          string `cbor:"tenant_id,omitempty" json:"tenant_id,omitempty"`
 	ClientID          string `cbor:"client_id,omitempty" json:"client_id,omitempty"`
+	ProofLevel        string `cbor:"proof_level,omitempty" json:"proof_level,omitempty"`
 	Query             string `cbor:"query,omitempty" json:"query,omitempty"`
 	ContentHashHex    string `cbor:"content_hash_hex,omitempty" json:"content_hash_hex,omitempty"`
 	ReceivedFromUnixN int64  `cbor:"received_from_unix_nano,omitempty" json:"received_from_unix_nano,omitempty"`
@@ -81,13 +85,16 @@ type GetProofBundleResponse struct {
 }
 
 type ListRootsRequest struct {
-	Limit int   `cbor:"limit" json:"limit"`
-	After int64 `cbor:"after,omitempty" json:"after,omitempty"`
+	Limit     int    `cbor:"limit" json:"limit"`
+	Direction string `cbor:"direction" json:"direction"`
+	Cursor    string `cbor:"cursor,omitempty" json:"cursor,omitempty"`
+	After     int64  `cbor:"after,omitempty" json:"after,omitempty"`
 }
 
 type ListRootsResponse struct {
 	Roots      []model.BatchRoot `cbor:"roots" json:"roots"`
 	Limit      int               `cbor:"limit" json:"limit"`
+	Direction  string            `cbor:"direction" json:"direction"`
 	NextCursor string            `cbor:"next_cursor,omitempty" json:"next_cursor,omitempty"`
 }
 
@@ -111,6 +118,19 @@ type GetSTHResponse struct {
 	STH model.SignedTreeHead `cbor:"sth" json:"sth"`
 }
 
+type ListSTHsRequest struct {
+	Limit     int    `cbor:"limit" json:"limit"`
+	Direction string `cbor:"direction" json:"direction"`
+	Cursor    string `cbor:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+type ListSTHsResponse struct {
+	STHs       []model.SignedTreeHead `cbor:"sths" json:"sths"`
+	Limit      int                    `cbor:"limit" json:"limit"`
+	Direction  string                 `cbor:"direction" json:"direction"`
+	NextCursor string                 `cbor:"next_cursor,omitempty" json:"next_cursor,omitempty"`
+}
+
 type GetGlobalProofRequest struct {
 	BatchID  string `cbor:"batch_id" json:"batch_id"`
 	TreeSize uint64 `cbor:"tree_size,omitempty" json:"tree_size,omitempty"`
@@ -118,6 +138,19 @@ type GetGlobalProofRequest struct {
 
 type GetGlobalProofResponse struct {
 	Proof model.GlobalLogProof `cbor:"proof" json:"proof"`
+}
+
+type ListGlobalLeavesRequest struct {
+	Limit     int    `cbor:"limit" json:"limit"`
+	Direction string `cbor:"direction" json:"direction"`
+	Cursor    string `cbor:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+type ListGlobalLeavesResponse struct {
+	Leaves     []model.GlobalLogLeaf `cbor:"leaves" json:"leaves"`
+	Limit      int                   `cbor:"limit" json:"limit"`
+	Direction  string                `cbor:"direction" json:"direction"`
+	NextCursor string                `cbor:"next_cursor,omitempty" json:"next_cursor,omitempty"`
 }
 
 type GetAnchorRequest struct {
@@ -130,6 +163,19 @@ type GetAnchorResponse struct {
 	ProofLevel string                     `cbor:"proof_level" json:"proof_level"`
 	Result     *model.STHAnchorResult     `cbor:"result,omitempty" json:"result,omitempty"`
 	Outbox     *model.STHAnchorOutboxItem `cbor:"outbox,omitempty" json:"outbox,omitempty"`
+}
+
+type ListAnchorsRequest struct {
+	Limit     int    `cbor:"limit" json:"limit"`
+	Direction string `cbor:"direction" json:"direction"`
+	Cursor    string `cbor:"cursor,omitempty" json:"cursor,omitempty"`
+}
+
+type ListAnchorsResponse struct {
+	Anchors    []GetAnchorResponse `cbor:"anchors" json:"anchors"`
+	Limit      int                 `cbor:"limit" json:"limit"`
+	Direction  string              `cbor:"direction" json:"direction"`
+	NextCursor string              `cbor:"next_cursor,omitempty" json:"next_cursor,omitempty"`
 }
 
 type MetricsRequest struct{}

--- a/internal/httpapi/handler.go
+++ b/internal/httpapi/handler.go
@@ -38,6 +38,7 @@ type BatchService interface {
 	Records(context.Context, model.RecordListOptions) ([]model.RecordIndex, error)
 	Roots(context.Context, int) ([]model.BatchRoot, error)
 	RootsAfter(context.Context, int64, int) ([]model.BatchRoot, error)
+	RootsPage(context.Context, model.RootListOptions) ([]model.BatchRoot, error)
 	LatestRoot(context.Context) (model.BatchRoot, error)
 }
 
@@ -47,11 +48,14 @@ type BatchService interface {
 type AnchorService interface {
 	AnchorResult(context.Context, uint64) (model.STHAnchorResult, bool, error)
 	AnchorStatus(context.Context, uint64) (model.STHAnchorOutboxItem, bool, error)
+	Anchors(context.Context, model.AnchorListOptions) ([]model.STHAnchorOutboxItem, error)
 }
 
 type GlobalLogService interface {
 	LatestSTH(context.Context) (model.SignedTreeHead, bool, error)
 	STH(context.Context, uint64) (model.SignedTreeHead, bool, error)
+	ListSTHs(context.Context, model.TreeHeadListOptions) ([]model.SignedTreeHead, error)
+	ListLeaves(context.Context, model.GlobalLeafListOptions) ([]model.GlobalLogLeaf, error)
 	InclusionProof(context.Context, string, uint64) (model.GlobalLogProof, error)
 	ConsistencyProof(context.Context, uint64, uint64) (model.GlobalConsistencyProof, error)
 }
@@ -80,6 +84,7 @@ type proofResponse struct {
 type rootsResponse struct {
 	Roots      []model.BatchRoot `json:"roots"`
 	Limit      int               `json:"limit"`
+	Direction  string            `json:"direction"`
 	NextCursor string            `json:"next_cursor,omitempty"`
 }
 
@@ -88,6 +93,27 @@ type recordsResponse struct {
 	Limit      int                 `json:"limit"`
 	Direction  string              `json:"direction"`
 	NextCursor string              `json:"next_cursor,omitempty"`
+}
+
+type sthsResponse struct {
+	STHs       []model.SignedTreeHead `json:"sths"`
+	Limit      int                    `json:"limit"`
+	Direction  string                 `json:"direction"`
+	NextCursor string                 `json:"next_cursor,omitempty"`
+}
+
+type globalLeavesResponse struct {
+	Leaves     []model.GlobalLogLeaf `json:"leaves"`
+	Limit      int                   `json:"limit"`
+	Direction  string                `json:"direction"`
+	NextCursor string                `json:"next_cursor,omitempty"`
+}
+
+type anchorsResponse struct {
+	Anchors    []anchorResponse `json:"anchors"`
+	Limit      int              `json:"limit"`
+	Direction  string           `json:"direction"`
+	NextCursor string           `json:"next_cursor,omitempty"`
 }
 
 type anchorResponse struct {
@@ -150,12 +176,15 @@ func buildMux(h Handler) http.Handler {
 	mux.HandleFunc("GET /v1/roots", h.listRoots)
 	mux.HandleFunc("GET /v1/roots/latest", h.latestRoot)
 	if h.Global != nil {
+		mux.HandleFunc("GET /v1/sth", h.listSTHs)
 		mux.HandleFunc("GET /v1/sth/latest", h.latestSTH)
 		mux.HandleFunc("GET /v1/sth/{tree_size}", h.getSTH)
+		mux.HandleFunc("GET /v1/global-log/leaves", h.listGlobalLeaves)
 		mux.HandleFunc("GET /v1/global-log/inclusion/{batch_id}", h.getGlobalInclusion)
 		mux.HandleFunc("GET /v1/global-log/consistency", h.getGlobalConsistency)
 	}
 	if h.Anchors != nil {
+		mux.HandleFunc("GET /v1/anchors/sth", h.listAnchors)
 		mux.HandleFunc("GET /v1/anchors/sth/{tree_size}", h.getAnchor)
 	}
 	if h.Metrics != nil {
@@ -283,42 +312,21 @@ func (h Handler) listRoots(w http.ResponseWriter, r *http.Request) {
 		writeError(w, trusterr.New(trusterr.CodeFailedPrecondition, "batch service is not configured"))
 		return
 	}
-	limit := 100
-	if raw := r.URL.Query().Get("limit"); raw != "" {
-		parsed, err := strconv.Atoi(raw)
-		if err != nil || parsed <= 0 || parsed > 1000 {
-			writeError(w, trusterr.New(trusterr.CodeInvalidArgument, "limit must be between 1 and 1000"))
-			return
-		}
-		limit = parsed
+	opts, err := parseRootListOptions(r)
+	if err != nil {
+		writeError(w, err)
+		return
 	}
-	after := int64(0)
-	if raw := r.URL.Query().Get("after"); raw != "" {
-		parsed, err := strconv.ParseInt(raw, 10, 64)
-		if err != nil || parsed < 0 {
-			writeError(w, trusterr.New(trusterr.CodeInvalidArgument, "after must be a non-negative unix nano cursor"))
-			return
-		}
-		after = parsed
-	}
-	var (
-		roots []model.BatchRoot
-		err   error
-	)
-	if after > 0 {
-		roots, err = h.Batch.RootsAfter(r.Context(), after, limit)
-	} else {
-		roots, err = h.Batch.Roots(r.Context(), limit)
-	}
+	roots, err := h.Batch.RootsPage(r.Context(), opts)
 	if err != nil {
 		writeError(w, err)
 		return
 	}
 	next := ""
-	if after > 0 && len(roots) == limit {
-		next = strconv.FormatInt(roots[len(roots)-1].ClosedAtUnixN, 10)
+	if len(roots) == opts.Limit {
+		next = encodeRootCursor(roots[len(roots)-1])
 	}
-	writeJSON(w, http.StatusOK, rootsResponse{Roots: roots, Limit: limit, NextCursor: next})
+	writeJSON(w, http.StatusOK, rootsResponse{Roots: roots, Limit: opts.Limit, Direction: opts.Direction, NextCursor: next})
 }
 
 func parseRecordListOptions(r *http.Request) (model.RecordListOptions, error) {
@@ -339,13 +347,18 @@ func parseRecordListOptions(r *http.Request) (model.RecordListOptions, error) {
 		return model.RecordListOptions{}, trusterr.New(trusterr.CodeInvalidArgument, "direction must be asc or desc")
 	}
 	opts := model.RecordListOptions{
-		Limit:     limit,
-		Direction: direction,
-		BatchID:   r.URL.Query().Get("batch_id"),
-		TenantID:  r.URL.Query().Get("tenant_id"),
-		ClientID:  r.URL.Query().Get("client_id"),
-		Query:     strings.TrimSpace(r.URL.Query().Get("q")),
+		Limit:      limit,
+		Direction:  direction,
+		BatchID:    r.URL.Query().Get("batch_id"),
+		TenantID:   r.URL.Query().Get("tenant_id"),
+		ClientID:   r.URL.Query().Get("client_id"),
+		ProofLevel: strings.ToUpper(strings.TrimSpace(r.URL.Query().Get("level"))),
+		Query:      strings.TrimSpace(r.URL.Query().Get("q")),
 	}
+	if opts.ProofLevel != "" && model.NormalizedProofLevel(opts.ProofLevel) == "" {
+		return model.RecordListOptions{}, trusterr.New(trusterr.CodeInvalidArgument, "level must be one of L1-L5")
+	}
+	opts.ProofLevel = model.NormalizedProofLevel(opts.ProofLevel)
 	if opts.BatchID == "" && strings.HasPrefix(strings.ToLower(opts.Query), "batch-") {
 		opts.BatchID = opts.Query
 		opts.Query = ""
@@ -385,6 +398,111 @@ func parseRecordListOptions(r *http.Request) (model.RecordListOptions, error) {
 		}
 		opts.AfterReceivedAtUnixN = cursor.ReceivedAtUnixN
 		opts.AfterRecordID = cursor.RecordID
+	}
+	return opts, nil
+}
+
+func parseRootListOptions(r *http.Request) (model.RootListOptions, error) {
+	limit := 100
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed <= 0 || parsed > 1000 {
+			return model.RootListOptions{}, trusterr.New(trusterr.CodeInvalidArgument, "limit must be between 1 and 1000")
+		}
+		limit = parsed
+	}
+	direction, err := parseDirection(r.URL.Query().Get("direction"))
+	if err != nil {
+		return model.RootListOptions{}, err
+	}
+	opts := model.RootListOptions{Limit: limit, Direction: direction}
+	if raw := r.URL.Query().Get("cursor"); raw != "" {
+		cursor, err := decodeRootCursor(raw)
+		if err != nil {
+			return model.RootListOptions{}, err
+		}
+		opts.AfterClosedAtUnixN = cursor.ClosedAtUnixN
+		opts.AfterBatchID = cursor.BatchID
+		return opts, nil
+	}
+	if raw := r.URL.Query().Get("after"); raw != "" {
+		parsed, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil || parsed < 0 {
+			return model.RootListOptions{}, trusterr.New(trusterr.CodeInvalidArgument, "after must be a non-negative unix nano cursor")
+		}
+		opts.AfterClosedAtUnixN = parsed
+	}
+	return opts, nil
+}
+
+func parseTreeHeadListOptions(r *http.Request) (model.TreeHeadListOptions, error) {
+	limit := 100
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed <= 0 || parsed > 1000 {
+			return model.TreeHeadListOptions{}, trusterr.New(trusterr.CodeInvalidArgument, "limit must be between 1 and 1000")
+		}
+		limit = parsed
+	}
+	direction, err := parseDirection(r.URL.Query().Get("direction"))
+	if err != nil {
+		return model.TreeHeadListOptions{}, err
+	}
+	opts := model.TreeHeadListOptions{Limit: limit, Direction: direction}
+	if raw := r.URL.Query().Get("cursor"); raw != "" {
+		cursor, err := decodeUint64Cursor(raw)
+		if err != nil {
+			return model.TreeHeadListOptions{}, err
+		}
+		opts.AfterTreeSize = cursor.Value
+	}
+	return opts, nil
+}
+
+func parseGlobalLeafListOptions(r *http.Request) (model.GlobalLeafListOptions, error) {
+	limit := 100
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed <= 0 || parsed > 1000 {
+			return model.GlobalLeafListOptions{}, trusterr.New(trusterr.CodeInvalidArgument, "limit must be between 1 and 1000")
+		}
+		limit = parsed
+	}
+	direction, err := parseDirection(r.URL.Query().Get("direction"))
+	if err != nil {
+		return model.GlobalLeafListOptions{}, err
+	}
+	opts := model.GlobalLeafListOptions{Limit: limit, Direction: direction}
+	if raw := r.URL.Query().Get("cursor"); raw != "" {
+		cursor, err := decodeUint64Cursor(raw)
+		if err != nil {
+			return model.GlobalLeafListOptions{}, err
+		}
+		opts.AfterLeafIndex = cursor.Value
+	}
+	return opts, nil
+}
+
+func parseAnchorListOptions(r *http.Request) (model.AnchorListOptions, error) {
+	limit := 100
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed <= 0 || parsed > 1000 {
+			return model.AnchorListOptions{}, trusterr.New(trusterr.CodeInvalidArgument, "limit must be between 1 and 1000")
+		}
+		limit = parsed
+	}
+	direction, err := parseDirection(r.URL.Query().Get("direction"))
+	if err != nil {
+		return model.AnchorListOptions{}, err
+	}
+	opts := model.AnchorListOptions{Limit: limit, Direction: direction}
+	if raw := r.URL.Query().Get("cursor"); raw != "" {
+		cursor, err := decodeUint64Cursor(raw)
+		if err != nil {
+			return model.AnchorListOptions{}, err
+		}
+		opts.AfterTreeSize = cursor.Value
 	}
 	return opts, nil
 }
@@ -466,6 +584,66 @@ func decodeRecordCursor(raw string) (recordCursor, error) {
 	return cursor, nil
 }
 
+type rootCursor struct {
+	ClosedAtUnixN int64  `json:"t"`
+	BatchID       string `json:"b"`
+}
+
+func encodeRootCursor(root model.BatchRoot) string {
+	data, err := json.Marshal(rootCursor{ClosedAtUnixN: root.ClosedAtUnixN, BatchID: root.BatchID})
+	if err != nil {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func decodeRootCursor(raw string) (rootCursor, error) {
+	data, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return rootCursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
+	}
+	var cursor rootCursor
+	if err := json.Unmarshal(data, &cursor); err != nil || cursor.BatchID == "" {
+		return rootCursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
+	}
+	return cursor, nil
+}
+
+type uint64Cursor struct {
+	Value uint64 `json:"v"`
+}
+
+func encodeUint64Cursor(value uint64) string {
+	data, err := json.Marshal(uint64Cursor{Value: value})
+	if err != nil {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func decodeUint64Cursor(raw string) (uint64Cursor, error) {
+	data, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return uint64Cursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
+	}
+	var cursor uint64Cursor
+	if err := json.Unmarshal(data, &cursor); err != nil {
+		return uint64Cursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
+	}
+	return cursor, nil
+}
+
+func parseDirection(raw string) (string, error) {
+	switch raw {
+	case "":
+		return model.RecordListDirectionDesc, nil
+	case model.RecordListDirectionAsc, model.RecordListDirectionDesc:
+		return raw, nil
+	default:
+		return "", trusterr.New(trusterr.CodeInvalidArgument, "direction must be asc or desc")
+	}
+}
+
 func (h Handler) latestSTH(w http.ResponseWriter, r *http.Request) {
 	if h.Global == nil {
 		writeError(w, trusterr.New(trusterr.CodeFailedPrecondition, "global log service is not configured"))
@@ -481,6 +659,33 @@ func (h Handler) latestSTH(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, sth)
+}
+
+func (h Handler) listSTHs(w http.ResponseWriter, r *http.Request) {
+	if h.Global == nil {
+		writeError(w, trusterr.New(trusterr.CodeFailedPrecondition, "global log service is not configured"))
+		return
+	}
+	opts, err := parseTreeHeadListOptions(r)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	sths, err := h.Global.ListSTHs(r.Context(), opts)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	next := ""
+	if len(sths) == opts.Limit {
+		next = encodeUint64Cursor(sths[len(sths)-1].TreeSize)
+	}
+	writeJSON(w, http.StatusOK, sthsResponse{
+		STHs:       sths,
+		Limit:      opts.Limit,
+		Direction:  opts.Direction,
+		NextCursor: next,
+	})
 }
 
 func (h Handler) getSTH(w http.ResponseWriter, r *http.Request) {
@@ -525,6 +730,33 @@ func (h Handler) getGlobalInclusion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, proof)
+}
+
+func (h Handler) listGlobalLeaves(w http.ResponseWriter, r *http.Request) {
+	if h.Global == nil {
+		writeError(w, trusterr.New(trusterr.CodeFailedPrecondition, "global log service is not configured"))
+		return
+	}
+	opts, err := parseGlobalLeafListOptions(r)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	leaves, err := h.Global.ListLeaves(r.Context(), opts)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	next := ""
+	if len(leaves) == opts.Limit {
+		next = encodeUint64Cursor(leaves[len(leaves)-1].LeafIndex)
+	}
+	writeJSON(w, http.StatusOK, globalLeavesResponse{
+		Leaves:     leaves,
+		Limit:      opts.Limit,
+		Direction:  opts.Direction,
+		NextCursor: next,
+	})
 }
 
 func (h Handler) getGlobalConsistency(w http.ResponseWriter, r *http.Request) {
@@ -584,6 +816,10 @@ func (h Handler) getAnchor(w http.ResponseWriter, r *http.Request) {
 		writeError(w, trusterr.New(trusterr.CodeNotFound, "anchor not found for STH"))
 		return
 	}
+	writeJSON(w, http.StatusOK, buildAnchorResponse(treeSize, item, itemOK, result, resultOK))
+}
+
+func buildAnchorResponse(treeSize uint64, item model.STHAnchorOutboxItem, itemOK bool, result model.STHAnchorResult, resultOK bool) anchorResponse {
 	resp := anchorResponse{TreeSize: treeSize, ProofLevel: prooflevel.L5.String()}
 	switch {
 	case resultOK:
@@ -599,7 +835,43 @@ func (h Handler) getAnchor(w http.ResponseWriter, r *http.Request) {
 		it := item
 		resp.Outbox = &it
 	}
-	writeJSON(w, http.StatusOK, resp)
+	return resp
+}
+
+func (h Handler) listAnchors(w http.ResponseWriter, r *http.Request) {
+	if h.Anchors == nil {
+		writeError(w, trusterr.New(trusterr.CodeFailedPrecondition, "anchor service is not configured"))
+		return
+	}
+	opts, err := parseAnchorListOptions(r)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	items, err := h.Anchors.Anchors(r.Context(), opts)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	anchors := make([]anchorResponse, 0, len(items))
+	for _, item := range items {
+		result, resultOK, err := h.Anchors.AnchorResult(r.Context(), item.TreeSize)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		anchors = append(anchors, buildAnchorResponse(item.TreeSize, item, true, result, resultOK))
+	}
+	next := ""
+	if len(items) == opts.Limit {
+		next = encodeUint64Cursor(items[len(items)-1].TreeSize)
+	}
+	writeJSON(w, http.StatusOK, anchorsResponse{
+		Anchors:    anchors,
+		Limit:      opts.Limit,
+		Direction:  opts.Direction,
+		NextCursor: next,
+	})
 }
 
 func (h Handler) latestRoot(w http.ResponseWriter, r *http.Request) {

--- a/internal/httpapi/handler_test.go
+++ b/internal/httpapi/handler_test.go
@@ -214,9 +214,9 @@ func TestRecordEndpoints(t *testing.T) {
 
 	batchSvc := &fakeBatchService{
 		records: []model.RecordIndex{
-			{SchemaVersion: model.SchemaRecordIndex, RecordID: "rec-3", TenantID: "tenant-b", BatchID: "batch-2", ReceivedAtUnixN: 300, ContentHash: bytes.Repeat([]byte{3}, 32), StorageURI: "file:///vault/report-final.pdf"},
-			{SchemaVersion: model.SchemaRecordIndex, RecordID: "rec-2", TenantID: "tenant-a", BatchID: "batch-1", ReceivedAtUnixN: 200, ContentHash: bytes.Repeat([]byte{2}, 32), StorageURI: "file:///vault/screenshot-alpha.png"},
-			{SchemaVersion: model.SchemaRecordIndex, RecordID: "rec-1", TenantID: "tenant-a", BatchID: "batch-1", ReceivedAtUnixN: 100, ContentHash: bytes.Repeat([]byte{1}, 32), StorageURI: "file:///vault/notes.txt"},
+			{SchemaVersion: model.SchemaRecordIndex, RecordID: "rec-3", TenantID: "tenant-b", BatchID: "batch-2", ProofLevel: "L5", ReceivedAtUnixN: 300, ContentHash: bytes.Repeat([]byte{3}, 32), StorageURI: "file:///vault/report-final.pdf"},
+			{SchemaVersion: model.SchemaRecordIndex, RecordID: "rec-2", TenantID: "tenant-a", BatchID: "batch-1", ProofLevel: "L4", ReceivedAtUnixN: 200, ContentHash: bytes.Repeat([]byte{2}, 32), StorageURI: "file:///vault/screenshot-alpha.png"},
+			{SchemaVersion: model.SchemaRecordIndex, RecordID: "rec-1", TenantID: "tenant-a", BatchID: "batch-1", ProofLevel: "L3", ReceivedAtUnixN: 100, ContentHash: bytes.Repeat([]byte{1}, 32), StorageURI: "file:///vault/notes.txt"},
 		},
 	}
 	handler := New(nil, nil, batchSvc)
@@ -304,6 +304,89 @@ func TestRecordEndpoints(t *testing.T) {
 	if len(byRange.Records) != 1 || byRange.Records[0].RecordID != "rec-2" {
 		t.Fatalf("range records page = %+v", byRange)
 	}
+
+	req = httptest.NewRequest(http.MethodGet, "/v1/records?level=L5&limit=10", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("records level status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var byLevel recordsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &byLevel); err != nil {
+		t.Fatalf("decode level records response: %v", err)
+	}
+	if len(byLevel.Records) != 1 || byLevel.Records[0].RecordID != "rec-3" {
+		t.Fatalf("level records page = %+v", byLevel)
+	}
+}
+
+func TestGlobalAndAnchorListEndpoints(t *testing.T) {
+	t.Parallel()
+
+	handler := NewWithGlobalAndAnchors(nil, nil, &fakeBatchService{}, fakeGlobalService{
+		sths: []model.SignedTreeHead{
+			{SchemaVersion: model.SchemaSignedTreeHead, TreeSize: 3, RootHash: []byte{3}},
+			{SchemaVersion: model.SchemaSignedTreeHead, TreeSize: 2, RootHash: []byte{2}},
+			{SchemaVersion: model.SchemaSignedTreeHead, TreeSize: 1, RootHash: []byte{1}},
+		},
+		leaves: []model.GlobalLogLeaf{
+			{SchemaVersion: model.SchemaGlobalLogLeaf, BatchID: "batch-3", LeafIndex: 2},
+			{SchemaVersion: model.SchemaGlobalLogLeaf, BatchID: "batch-2", LeafIndex: 1},
+			{SchemaVersion: model.SchemaGlobalLogLeaf, BatchID: "batch-1", LeafIndex: 0},
+		},
+	}, fakeAnchorService{
+		items: []model.STHAnchorOutboxItem{
+			{SchemaVersion: model.SchemaSTHAnchorOutbox, TreeSize: 3, Status: model.AnchorStatePending},
+			{SchemaVersion: model.SchemaSTHAnchorOutbox, TreeSize: 2, Status: model.AnchorStatePublished},
+			{SchemaVersion: model.SchemaSTHAnchorOutbox, TreeSize: 1, Status: model.AnchorStatePublished},
+		},
+		results: map[uint64]model.STHAnchorResult{
+			2: {SchemaVersion: model.SchemaSTHAnchorResult, TreeSize: 2, AnchorID: "anchor-2", SinkName: "ots"},
+			1: {SchemaVersion: model.SchemaSTHAnchorResult, TreeSize: 1, AnchorID: "anchor-1", SinkName: "ots"},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/sth?limit=2", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("sth list status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var sthsPage sthsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &sthsPage); err != nil {
+		t.Fatalf("decode sth page: %v", err)
+	}
+	if len(sthsPage.STHs) != 2 || sthsPage.STHs[0].TreeSize != 3 || sthsPage.NextCursor == "" {
+		t.Fatalf("sth page = %+v", sthsPage)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/v1/global-log/leaves?limit=2", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("global leaves status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var leavesPage globalLeavesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &leavesPage); err != nil {
+		t.Fatalf("decode leaves page: %v", err)
+	}
+	if len(leavesPage.Leaves) != 2 || leavesPage.Leaves[0].LeafIndex != 2 || leavesPage.NextCursor == "" {
+		t.Fatalf("leaves page = %+v", leavesPage)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/v1/anchors/sth?limit=2", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("anchor list status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var anchorsPage anchorsResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &anchorsPage); err != nil {
+		t.Fatalf("decode anchor page: %v", err)
+	}
+	if len(anchorsPage.Anchors) != 2 || anchorsPage.Anchors[0].TreeSize != 3 || anchorsPage.NextCursor == "" {
+		t.Fatalf("anchor page = %+v", anchorsPage)
+	}
 }
 
 type processorFunc func(context.Context, model.SignedClaim) (model.ServerRecord, model.AcceptedReceipt, bool, error)
@@ -390,6 +473,29 @@ func (f *fakeBatchService) RootsAfter(ctx context.Context, afterClosedAtUnixN in
 	return out, nil
 }
 
+func (f *fakeBatchService) RootsPage(ctx context.Context, opts model.RootListOptions) ([]model.BatchRoot, error) {
+	roots := append([]model.BatchRoot(nil), f.roots...)
+	desc := !strings.EqualFold(opts.Direction, model.RecordListDirectionAsc)
+	sort.Slice(roots, func(i, j int) bool {
+		cmp := model.CompareBatchRootPosition(roots[i].ClosedAtUnixN, roots[i].BatchID, roots[j].ClosedAtUnixN, roots[j].BatchID)
+		if desc {
+			return cmp > 0
+		}
+		return cmp < 0
+	})
+	out := make([]model.BatchRoot, 0, opts.Limit)
+	for _, root := range roots {
+		if !model.BatchRootAfterCursor(root, opts) {
+			continue
+		}
+		out = append(out, root)
+		if len(out) >= opts.Limit {
+			break
+		}
+	}
+	return out, nil
+}
+
 func (f *fakeBatchService) LatestRoot(ctx context.Context) (model.BatchRoot, error) {
 	if len(f.roots) == 0 {
 		return model.BatchRoot{}, nil
@@ -401,4 +507,121 @@ func (f *fakeBatchService) enqueuedRecordID() string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.enqueued
+}
+
+type fakeGlobalService struct {
+	sths   []model.SignedTreeHead
+	leaves []model.GlobalLogLeaf
+}
+
+func (f fakeGlobalService) LatestSTH(context.Context) (model.SignedTreeHead, bool, error) {
+	if len(f.sths) == 0 {
+		return model.SignedTreeHead{}, false, nil
+	}
+	return f.sths[0], true, nil
+}
+
+func (f fakeGlobalService) STH(_ context.Context, treeSize uint64) (model.SignedTreeHead, bool, error) {
+	for _, sth := range f.sths {
+		if sth.TreeSize == treeSize {
+			return sth, true, nil
+		}
+	}
+	return model.SignedTreeHead{}, false, nil
+}
+
+func (f fakeGlobalService) ListSTHs(_ context.Context, opts model.TreeHeadListOptions) ([]model.SignedTreeHead, error) {
+	sths := append([]model.SignedTreeHead(nil), f.sths...)
+	desc := !strings.EqualFold(opts.Direction, model.RecordListDirectionAsc)
+	sort.Slice(sths, func(i, j int) bool {
+		cmp := model.CompareUint64Position(sths[i].TreeSize, sths[j].TreeSize)
+		if desc {
+			return cmp > 0
+		}
+		return cmp < 0
+	})
+	out := make([]model.SignedTreeHead, 0, opts.Limit)
+	for _, sth := range sths {
+		if !model.Uint64AfterCursor(sth.TreeSize, opts.AfterTreeSize, opts.Direction) {
+			continue
+		}
+		out = append(out, sth)
+		if len(out) >= opts.Limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (f fakeGlobalService) ListLeaves(_ context.Context, opts model.GlobalLeafListOptions) ([]model.GlobalLogLeaf, error) {
+	leaves := append([]model.GlobalLogLeaf(nil), f.leaves...)
+	desc := !strings.EqualFold(opts.Direction, model.RecordListDirectionAsc)
+	sort.Slice(leaves, func(i, j int) bool {
+		cmp := model.CompareUint64Position(leaves[i].LeafIndex, leaves[j].LeafIndex)
+		if desc {
+			return cmp > 0
+		}
+		return cmp < 0
+	})
+	out := make([]model.GlobalLogLeaf, 0, opts.Limit)
+	for _, leaf := range leaves {
+		if !model.Uint64AfterCursor(leaf.LeafIndex, opts.AfterLeafIndex, opts.Direction) {
+			continue
+		}
+		out = append(out, leaf)
+		if len(out) >= opts.Limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (f fakeGlobalService) InclusionProof(context.Context, string, uint64) (model.GlobalLogProof, error) {
+	return model.GlobalLogProof{}, nil
+}
+
+func (f fakeGlobalService) ConsistencyProof(context.Context, uint64, uint64) (model.GlobalConsistencyProof, error) {
+	return model.GlobalConsistencyProof{}, nil
+}
+
+type fakeAnchorService struct {
+	items   []model.STHAnchorOutboxItem
+	results map[uint64]model.STHAnchorResult
+}
+
+func (f fakeAnchorService) AnchorResult(_ context.Context, treeSize uint64) (model.STHAnchorResult, bool, error) {
+	result, ok := f.results[treeSize]
+	return result, ok, nil
+}
+
+func (f fakeAnchorService) AnchorStatus(_ context.Context, treeSize uint64) (model.STHAnchorOutboxItem, bool, error) {
+	for _, item := range f.items {
+		if item.TreeSize == treeSize {
+			return item, true, nil
+		}
+	}
+	return model.STHAnchorOutboxItem{}, false, nil
+}
+
+func (f fakeAnchorService) Anchors(_ context.Context, opts model.AnchorListOptions) ([]model.STHAnchorOutboxItem, error) {
+	items := append([]model.STHAnchorOutboxItem(nil), f.items...)
+	desc := !strings.EqualFold(opts.Direction, model.RecordListDirectionAsc)
+	sort.Slice(items, func(i, j int) bool {
+		cmp := model.CompareUint64Position(items[i].TreeSize, items[j].TreeSize)
+		if desc {
+			return cmp > 0
+		}
+		return cmp < 0
+	})
+	out := make([]model.STHAnchorOutboxItem, 0, opts.Limit)
+	for _, item := range items {
+		if !model.Uint64AfterCursor(item.TreeSize, opts.AfterTreeSize, opts.Direction) {
+			continue
+		}
+		out = append(out, item)
+		if len(out) >= opts.Limit {
+			break
+		}
+	}
+	return out, nil
 }

--- a/internal/model/pagination.go
+++ b/internal/model/pagination.go
@@ -1,0 +1,95 @@
+package model
+
+import "strings"
+
+func NormalizedProofLevel(raw string) string {
+	switch strings.ToUpper(strings.TrimSpace(raw)) {
+	case "L1":
+		return "L1"
+	case "L2":
+		return "L2"
+	case "L3":
+		return "L3"
+	case "L4":
+		return "L4"
+	case "L5":
+		return "L5"
+	default:
+		return ""
+	}
+}
+
+func ProofLevelRank(raw string) int {
+	switch NormalizedProofLevel(raw) {
+	case "L1":
+		return 1
+	case "L2":
+		return 2
+	case "L3":
+		return 3
+	case "L4":
+		return 4
+	case "L5":
+		return 5
+	default:
+		return 0
+	}
+}
+
+func RecordIndexProofLevel(idx RecordIndex) string {
+	if level := NormalizedProofLevel(idx.ProofLevel); level != "" {
+		return level
+	}
+	if idx.BatchID != "" {
+		return "L3"
+	}
+	return "L2"
+}
+
+func CompareBatchRootPosition(leftTime int64, leftBatchID string, rightTime int64, rightBatchID string) int {
+	switch {
+	case leftTime < rightTime:
+		return -1
+	case leftTime > rightTime:
+		return 1
+	case leftBatchID < rightBatchID:
+		return -1
+	case leftBatchID > rightBatchID:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func BatchRootAfterCursor(root BatchRoot, opts RootListOptions) bool {
+	if opts.AfterClosedAtUnixN == 0 && opts.AfterBatchID == "" {
+		return true
+	}
+	cmp := CompareBatchRootPosition(root.ClosedAtUnixN, root.BatchID, opts.AfterClosedAtUnixN, opts.AfterBatchID)
+	if strings.EqualFold(opts.Direction, RecordListDirectionAsc) {
+		return cmp > 0
+	}
+	return cmp < 0
+}
+
+func CompareUint64Position(left, right uint64) int {
+	switch {
+	case left < right:
+		return -1
+	case left > right:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func Uint64AfterCursor(value, after uint64, direction string) bool {
+	if after == 0 {
+		return true
+	}
+	cmp := CompareUint64Position(value, after)
+	if strings.EqualFold(direction, RecordListDirectionAsc) {
+		return cmp > 0
+	}
+	return cmp < 0
+}

--- a/internal/model/record_index.go
+++ b/internal/model/record_index.go
@@ -23,6 +23,9 @@ func RecordIndexMatchesListOptions(idx RecordIndex, opts RecordListOptions) bool
 	if opts.ClientID != "" && idx.ClientID != opts.ClientID {
 		return false
 	}
+	if opts.ProofLevel != "" && RecordIndexProofLevel(idx) != opts.ProofLevel {
+		return false
+	}
 	if len(opts.ContentHash) > 0 && !bytes.Equal(idx.ContentHash, opts.ContentHash) {
 		return false
 	}

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -184,6 +184,7 @@ type RecordIndex struct {
 	TenantID           string `cbor:"tenant_id,omitempty" json:"tenant_id,omitempty"`
 	ClientID           string `cbor:"client_id,omitempty" json:"client_id,omitempty"`
 	KeyID              string `cbor:"key_id,omitempty" json:"key_id,omitempty"`
+	ProofLevel         string `cbor:"proof_level,omitempty" json:"proof_level,omitempty"`
 	BatchID            string `cbor:"batch_id,omitempty" json:"batch_id,omitempty"`
 	BatchLeafIndex     uint64 `cbor:"batch_leaf_index" json:"batch_leaf_index"`
 	BatchClosedAtUnixN int64  `cbor:"batch_closed_at_unix_nano,omitempty" json:"batch_closed_at_unix_nano,omitempty"`
@@ -203,6 +204,7 @@ type RecordListOptions struct {
 	BatchID              string
 	TenantID             string
 	ClientID             string
+	ProofLevel           string
 	Query                string
 	ContentHash          []byte
 	ReceivedFromUnixN    int64
@@ -215,6 +217,31 @@ const (
 	RecordListDirectionAsc  = "asc"
 	RecordListDirectionDesc = "desc"
 )
+
+type RootListOptions struct {
+	Limit              int
+	Direction          string
+	AfterClosedAtUnixN int64
+	AfterBatchID       string
+}
+
+type TreeHeadListOptions struct {
+	Limit         int
+	Direction     string
+	AfterTreeSize uint64
+}
+
+type GlobalLeafListOptions struct {
+	Limit          int
+	Direction      string
+	AfterLeafIndex uint64
+}
+
+type AnchorListOptions struct {
+	Limit         int
+	Direction     string
+	AfterTreeSize uint64
+}
 
 func RecordIndexFromBundle(bundle ProofBundle) RecordIndex {
 	claim := bundle.SignedClaim.Claim
@@ -247,6 +274,7 @@ func RecordIndexFromBundle(bundle ProofBundle) RecordIndex {
 		TenantID:           tenantID,
 		ClientID:           clientID,
 		KeyID:              keyID,
+		ProofLevel:         "L3",
 		BatchID:            bundle.CommittedReceipt.BatchID,
 		BatchLeafIndex:     bundle.CommittedReceipt.LeafIndex,
 		BatchClosedAtUnixN: bundle.CommittedReceipt.ClosedAtUnixN,

--- a/internal/proofstore/local.go
+++ b/internal/proofstore/local.go
@@ -29,17 +29,37 @@ func (s LocalStore) PutBundle(ctx context.Context, bundle model.ProofBundle) err
 	if bundle.RecordID == "" {
 		return trusterr.New(trusterr.CodeInvalidArgument, "proof bundle record_id is required")
 	}
-	if existing, ok, err := s.GetRecordIndex(ctx, bundle.RecordID); err != nil {
-		return err
-	} else if ok {
-		s.removeRecordIndex(existing)
-	}
 	path := filepath.Join(s.bundleDir(), safeFileName(bundle.RecordID)+".tdproof")
 	if err := writeCBORAtomic(path, bundle); err != nil {
 		return trusterr.Wrap(trusterr.CodeDataLoss, "write proof bundle", err)
 	}
-	if err := s.writeRecordIndex(model.RecordIndexFromBundle(bundle)); err != nil {
+	if err := s.PutRecordIndex(ctx, model.RecordIndexFromBundle(bundle)); err != nil {
 		return trusterr.Wrap(trusterr.CodeDataLoss, "write record index", err)
+	}
+	return nil
+}
+
+func (s LocalStore) PutRecordIndex(ctx context.Context, idx model.RecordIndex) error {
+	if err := ctx.Err(); err != nil {
+		return trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore put record index canceled", err)
+	}
+	if idx.RecordID == "" {
+		return trusterr.New(trusterr.CodeInvalidArgument, "record index record_id is required")
+	}
+	var old model.RecordIndex
+	oldFound := false
+	if existing, ok, err := s.GetRecordIndex(ctx, idx.RecordID); err != nil {
+		return err
+	} else if ok {
+		old = existing
+		oldFound = true
+	}
+	idx.ProofLevel = model.RecordIndexProofLevel(idx)
+	if err := s.writeRecordIndex(idx); err != nil {
+		return trusterr.Wrap(trusterr.CodeDataLoss, "write record index", err)
+	}
+	if oldFound {
+		s.removeRecordIndexSecondary(old, idx)
 	}
 	return nil
 }
@@ -100,6 +120,8 @@ func (s LocalStore) ListRecordIndexes(ctx context.Context, opts model.RecordList
 		dir = s.recordByStorageTokenDir(model.RecordStorageQueryToken(opts.Query))
 	case opts.BatchID != "":
 		dir = s.recordByBatchDir(opts.BatchID)
+	case opts.ProofLevel != "":
+		dir = s.recordByProofLevelDir(opts.ProofLevel)
 	case opts.TenantID != "":
 		dir = s.recordByTenantDir(opts.TenantID)
 	case opts.ClientID != "":
@@ -246,6 +268,46 @@ func (s LocalStore) ListRootsAfter(ctx context.Context, afterClosedAtUnixN int64
 		if len(roots) >= limit {
 			break
 		}
+	}
+	return roots, nil
+}
+
+func (s LocalStore) ListRootsPage(ctx context.Context, opts model.RootListOptions) ([]model.BatchRoot, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list roots page canceled", err)
+	}
+	limit := normaliseRecordLimit(opts.Limit)
+	entries, err := os.ReadDir(s.rootDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "read root directory", err)
+	}
+	roots := make([]model.BatchRoot, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".tdroot") {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list roots page canceled", err)
+		}
+		data, err := os.ReadFile(filepath.Join(s.rootDir(), entry.Name()))
+		if err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "read batch root", err)
+		}
+		var root model.BatchRoot
+		if err := cborx.UnmarshalLimit(data, &root, maxStoredObjectBytes); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "decode batch root", err)
+		}
+		if !model.BatchRootAfterCursor(root, opts) {
+			continue
+		}
+		roots = append(roots, root)
+	}
+	sortBatchRoots(roots, opts.Direction)
+	if len(roots) > limit {
+		roots = roots[:limit]
 	}
 	return roots, nil
 }
@@ -672,6 +734,46 @@ func (s LocalStore) ListGlobalLeavesRange(ctx context.Context, startIndex uint64
 	return leaves, nil
 }
 
+func (s LocalStore) ListGlobalLeavesPage(ctx context.Context, opts model.GlobalLeafListOptions) ([]model.GlobalLogLeaf, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list global leaves page canceled", err)
+	}
+	limit := normaliseRecordLimit(opts.Limit)
+	entries, err := os.ReadDir(s.globalLeafDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "read global leaf directory", err)
+	}
+	leaves := make([]model.GlobalLogLeaf, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".tdgleaf") {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list global leaves page canceled", err)
+		}
+		data, err := os.ReadFile(filepath.Join(s.globalLeafDir(), entry.Name()))
+		if err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "read global log leaf", err)
+		}
+		var leaf model.GlobalLogLeaf
+		if err := cborx.UnmarshalLimit(data, &leaf, maxStoredObjectBytes); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "decode global log leaf", err)
+		}
+		if !model.Uint64AfterCursor(leaf.LeafIndex, opts.AfterLeafIndex, opts.Direction) {
+			continue
+		}
+		leaves = append(leaves, leaf)
+	}
+	sortGlobalLeaves(leaves, opts.Direction)
+	if len(leaves) > limit {
+		leaves = leaves[:limit]
+	}
+	return leaves, nil
+}
+
 func (s LocalStore) PutSignedTreeHead(ctx context.Context, sth model.SignedTreeHead) error {
 	if err := ctx.Err(); err != nil {
 		return trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore put sth canceled", err)
@@ -731,6 +833,46 @@ func (s LocalStore) ListSignedTreeHeadsAfter(ctx context.Context, afterTreeSize 
 		out = append(out, sth)
 	}
 	return out, nil
+}
+
+func (s LocalStore) ListSignedTreeHeadsPage(ctx context.Context, opts model.TreeHeadListOptions) ([]model.SignedTreeHead, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list signed tree heads page canceled", err)
+	}
+	limit := normaliseRecordLimit(opts.Limit)
+	entries, err := os.ReadDir(s.sthDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "read signed tree head directory", err)
+	}
+	sths := make([]model.SignedTreeHead, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".tdsth") {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list signed tree heads page canceled", err)
+		}
+		data, err := os.ReadFile(filepath.Join(s.sthDir(), entry.Name()))
+		if err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "read signed tree head", err)
+		}
+		var sth model.SignedTreeHead
+		if err := cborx.UnmarshalLimit(data, &sth, maxStoredObjectBytes); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "decode signed tree head", err)
+		}
+		if !model.Uint64AfterCursor(sth.TreeSize, opts.AfterTreeSize, opts.Direction) {
+			continue
+		}
+		sths = append(sths, sth)
+	}
+	sortSignedTreeHeads(sths, opts.Direction)
+	if len(sths) > limit {
+		sths = sths[:limit]
+	}
+	return sths, nil
 }
 
 func (s LocalStore) LatestSignedTreeHead(ctx context.Context) (model.SignedTreeHead, bool, error) {
@@ -988,6 +1130,9 @@ func (s LocalStore) MarkGlobalLogPublished(ctx context.Context, batchID string, 
 	if err := writeCBORAtomic(s.globalOutboxPath(batchID), item); err != nil {
 		return trusterr.Wrap(trusterr.CodeDataLoss, "update global log outbox item", err)
 	}
+	if err := s.promoteBatchRecords(ctx, batchID, "L4"); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1161,6 +1306,46 @@ func (s LocalStore) ListSTHAnchorOutboxItemsAfter(ctx context.Context, afterTree
 	return items, nil
 }
 
+func (s LocalStore) ListSTHAnchorsPage(ctx context.Context, opts model.AnchorListOptions) ([]model.STHAnchorOutboxItem, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list sth anchors page canceled", err)
+	}
+	limit := normaliseRecordLimit(opts.Limit)
+	entries, err := os.ReadDir(s.sthAnchorOutboxDir())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "read sth anchor outbox directory", err)
+	}
+	items := make([]model.STHAnchorOutboxItem, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".tdsth-anchor") {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list sth anchors page canceled", err)
+		}
+		data, err := os.ReadFile(filepath.Join(s.sthAnchorOutboxDir(), entry.Name()))
+		if err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "read sth anchor outbox item", err)
+		}
+		var item model.STHAnchorOutboxItem
+		if err := cborx.UnmarshalLimit(data, &item, maxStoredObjectBytes); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "decode sth anchor outbox item", err)
+		}
+		if !model.Uint64AfterCursor(item.TreeSize, opts.AfterTreeSize, opts.Direction) {
+			continue
+		}
+		items = append(items, item)
+	}
+	sortSTHAnchorsByTreeSize(items, opts.Direction)
+	if len(items) > limit {
+		items = items[:limit]
+	}
+	return items, nil
+}
+
 func (s LocalStore) RescheduleSTHAnchor(ctx context.Context, treeSize uint64, attempts int, nextAttemptUnixN int64, lastErrorMessage string) error {
 	item, ok, err := s.GetSTHAnchorOutboxItem(ctx, treeSize)
 	if err != nil {
@@ -1209,6 +1394,15 @@ func (s LocalStore) MarkSTHAnchorPublished(ctx context.Context, result model.STH
 	item.NextAttemptUnixN = 0
 	if err := writeCBORAtomic(s.sthAnchorOutboxPath(result.TreeSize), item); err != nil {
 		return trusterr.Wrap(trusterr.CodeDataLoss, "update sth anchor outbox item", err)
+	}
+	leaf, ok, err := s.GetGlobalLeaf(ctx, result.TreeSize-1)
+	if err != nil {
+		return err
+	}
+	if ok {
+		if err := s.promoteBatchRecords(ctx, leaf.BatchID, "L5"); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -1380,6 +1574,10 @@ func (s LocalStore) recordByBatchDir(batchID string) string {
 	return filepath.Join(s.root(), "records", "by-batch", safeFileName(batchID))
 }
 
+func (s LocalStore) recordByProofLevelDir(level string) string {
+	return filepath.Join(s.root(), "records", "by-proof-level", safeFileName(level))
+}
+
 func (s LocalStore) recordByTenantDir(tenantID string) string {
 	return filepath.Join(s.root(), "records", "by-tenant", safeFileName(tenantID))
 }
@@ -1453,26 +1651,14 @@ func (s LocalStore) writeRecordIndex(idx model.RecordIndex) error {
 	if idx.SchemaVersion == "" {
 		idx.SchemaVersion = model.SchemaRecordIndex
 	}
-	paths := []string{
-		s.recordByIDPath(idx.RecordID),
-		filepath.Join(s.recordByTimeDir(), s.recordIndexName(idx)),
+	// Keep record-by-id continuously readable while secondary indexes are
+	// being promoted (for example L3 -> L4 -> L5). List queries may briefly
+	// observe stale secondary entries, but direct GetRecord lookups should
+	// never see a missing record during index replacement.
+	if err := writeCBORAtomic(s.recordByIDPath(idx.RecordID), idx); err != nil {
+		return err
 	}
-	if idx.BatchID != "" {
-		paths = append(paths, filepath.Join(s.recordByBatchDir(idx.BatchID), s.recordIndexName(idx)))
-	}
-	if idx.TenantID != "" {
-		paths = append(paths, filepath.Join(s.recordByTenantDir(idx.TenantID), s.recordIndexName(idx)))
-	}
-	if idx.ClientID != "" {
-		paths = append(paths, filepath.Join(s.recordByClientDir(idx.ClientID), s.recordIndexName(idx)))
-	}
-	if len(idx.ContentHash) > 0 {
-		paths = append(paths, filepath.Join(s.recordByContentDir(idx.ContentHash), s.recordIndexName(idx)))
-	}
-	for _, token := range model.RecordIndexStorageTokens(idx) {
-		paths = append(paths, filepath.Join(s.recordByStorageTokenDir(token), s.recordIndexName(idx)))
-	}
-	for _, path := range paths {
+	for _, path := range s.recordIndexSecondaryPaths(idx) {
 		if err := writeCBORAtomic(path, idx); err != nil {
 			return err
 		}
@@ -1481,12 +1667,37 @@ func (s LocalStore) writeRecordIndex(idx model.RecordIndex) error {
 }
 
 func (s LocalStore) removeRecordIndex(idx model.RecordIndex) {
+	paths := append([]string{s.recordByIDPath(idx.RecordID)}, s.recordIndexSecondaryPaths(idx)...)
+	for _, path := range paths {
+		_ = os.Remove(path)
+	}
+}
+
+func (s LocalStore) removeRecordIndexSecondary(old, next model.RecordIndex) {
+	if old.RecordID == "" {
+		return
+	}
+	keep := make(map[string]struct{}, 8)
+	for _, path := range s.recordIndexSecondaryPaths(next) {
+		keep[path] = struct{}{}
+	}
+	for _, path := range s.recordIndexSecondaryPaths(old) {
+		if _, ok := keep[path]; ok {
+			continue
+		}
+		_ = os.Remove(path)
+	}
+}
+
+func (s LocalStore) recordIndexSecondaryPaths(idx model.RecordIndex) []string {
 	paths := []string{
-		s.recordByIDPath(idx.RecordID),
 		filepath.Join(s.recordByTimeDir(), s.recordIndexName(idx)),
 	}
 	if idx.BatchID != "" {
 		paths = append(paths, filepath.Join(s.recordByBatchDir(idx.BatchID), s.recordIndexName(idx)))
+	}
+	if idx.ProofLevel != "" {
+		paths = append(paths, filepath.Join(s.recordByProofLevelDir(idx.ProofLevel), s.recordIndexName(idx)))
 	}
 	if idx.TenantID != "" {
 		paths = append(paths, filepath.Join(s.recordByTenantDir(idx.TenantID), s.recordIndexName(idx)))
@@ -1500,9 +1711,7 @@ func (s LocalStore) removeRecordIndex(idx model.RecordIndex) {
 	for _, token := range model.RecordIndexStorageTokens(idx) {
 		paths = append(paths, filepath.Join(s.recordByStorageTokenDir(token), s.recordIndexName(idx)))
 	}
-	for _, path := range paths {
-		_ = os.Remove(path)
-	}
+	return paths
 }
 
 func normaliseRecordLimit(limit int) int {
@@ -1515,6 +1724,17 @@ func normaliseRecordLimit(limit int) int {
 	return limit
 }
 
+func sortBatchRoots(roots []model.BatchRoot, direction string) {
+	desc := !strings.EqualFold(direction, model.RecordListDirectionAsc)
+	sort.Slice(roots, func(i, j int) bool {
+		cmp := model.CompareBatchRootPosition(roots[i].ClosedAtUnixN, roots[i].BatchID, roots[j].ClosedAtUnixN, roots[j].BatchID)
+		if desc {
+			return cmp > 0
+		}
+		return cmp < 0
+	})
+}
+
 func sortRecordIndexes(indexes []model.RecordIndex, direction string) {
 	desc := !strings.EqualFold(direction, model.RecordListDirectionAsc)
 	sort.Slice(indexes, func(i, j int) bool {
@@ -1524,6 +1744,76 @@ func sortRecordIndexes(indexes []model.RecordIndex, direction string) {
 		}
 		return cmp < 0
 	})
+}
+
+func sortSignedTreeHeads(sths []model.SignedTreeHead, direction string) {
+	desc := !strings.EqualFold(direction, model.RecordListDirectionAsc)
+	sort.Slice(sths, func(i, j int) bool {
+		cmp := model.CompareUint64Position(sths[i].TreeSize, sths[j].TreeSize)
+		if desc {
+			return cmp > 0
+		}
+		return cmp < 0
+	})
+}
+
+func sortGlobalLeaves(leaves []model.GlobalLogLeaf, direction string) {
+	desc := !strings.EqualFold(direction, model.RecordListDirectionAsc)
+	sort.Slice(leaves, func(i, j int) bool {
+		cmp := model.CompareUint64Position(leaves[i].LeafIndex, leaves[j].LeafIndex)
+		if desc {
+			return cmp > 0
+		}
+		return cmp < 0
+	})
+}
+
+func sortSTHAnchorsByTreeSize(items []model.STHAnchorOutboxItem, direction string) {
+	desc := !strings.EqualFold(direction, model.RecordListDirectionAsc)
+	sort.Slice(items, func(i, j int) bool {
+		cmp := model.CompareUint64Position(items[i].TreeSize, items[j].TreeSize)
+		if desc {
+			return cmp > 0
+		}
+		return cmp < 0
+	})
+}
+
+func (s LocalStore) promoteBatchRecords(ctx context.Context, batchID, proofLevel string) error {
+	if batchID == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(s.recordByBatchDir(batchID))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return trusterr.Wrap(trusterr.CodeDataLoss, "read batch record index directory", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".tdrecord") {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return trusterr.Wrap(trusterr.CodeDeadlineExceeded, "promote batch record indexes canceled", err)
+		}
+		data, err := os.ReadFile(filepath.Join(s.recordByBatchDir(batchID), entry.Name()))
+		if err != nil {
+			return trusterr.Wrap(trusterr.CodeDataLoss, "read batch record index", err)
+		}
+		var idx model.RecordIndex
+		if err := cborx.UnmarshalLimit(data, &idx, maxStoredObjectBytes); err != nil {
+			return trusterr.Wrap(trusterr.CodeDataLoss, "decode batch record index", err)
+		}
+		if model.ProofLevelRank(model.RecordIndexProofLevel(idx)) >= model.ProofLevelRank(proofLevel) {
+			continue
+		}
+		idx.ProofLevel = proofLevel
+		if err := s.PutRecordIndex(ctx, idx); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func safeFileName(value string) string {

--- a/internal/proofstore/pebble/store.go
+++ b/internal/proofstore/pebble/store.go
@@ -34,6 +34,7 @@ const (
 	prefixRecordByID     = "record/by-id/"
 	prefixRecordByTime   = "record/by-time/"
 	prefixRecordByBatch  = "record/by-batch/"
+	prefixRecordByLevel  = "record/by-proof-level/"
 	prefixRecordByTenant = "record/by-tenant/"
 	prefixRecordByClient = "record/by-client/"
 	prefixRecordByHash   = "record/by-content/"
@@ -124,6 +125,9 @@ func recordIndexPrefixes(idx model.RecordIndex) []string {
 	prefixes := []string{prefixRecordByTime}
 	if idx.BatchID != "" {
 		prefixes = append(prefixes, prefixRecordByBatch+recordSecondaryPart(idx.BatchID)+"/")
+	}
+	if idx.ProofLevel != "" {
+		prefixes = append(prefixes, prefixRecordByLevel+recordSecondaryPart(idx.ProofLevel)+"/")
 	}
 	if idx.TenantID != "" {
 		prefixes = append(prefixes, prefixRecordByTenant+recordSecondaryPart(idx.TenantID)+"/")
@@ -217,13 +221,6 @@ func (s *Store) PutBundle(ctx context.Context, bundle model.ProofBundle) error {
 		return trusterr.Wrap(trusterr.CodeDataLoss, "encode proof bundle", err)
 	}
 	idx := model.RecordIndexFromBundle(bundle)
-	if idx.SchemaVersion == "" {
-		idx.SchemaVersion = model.SchemaRecordIndex
-	}
-	indexData, err := cborx.Marshal(idx)
-	if err != nil {
-		return trusterr.Wrap(trusterr.CodeDataLoss, "encode record index", err)
-	}
 	var old model.RecordIndex
 	oldFound, err := s.readCBOR(recordByIDKey(bundle.RecordID), &old)
 	if err != nil {
@@ -231,23 +228,37 @@ func (s *Store) PutBundle(ctx context.Context, bundle model.ProofBundle) error {
 	}
 	batch := s.db.NewBatch()
 	defer batch.Close()
-	if oldFound {
-		for _, key := range recordIndexKeys(old) {
-			if err := batch.Delete(key, nil); err != nil {
-				return trusterr.Wrap(trusterr.CodeDataLoss, "stage old record index delete", err)
-			}
-		}
-	}
 	if err := batch.Set(bundleKey(bundle.RecordID), bundleData, nil); err != nil {
 		return trusterr.Wrap(trusterr.CodeDataLoss, "stage proof bundle", err)
 	}
-	for _, key := range recordIndexKeys(idx) {
-		if err := batch.Set(key, indexData, nil); err != nil {
-			return trusterr.Wrap(trusterr.CodeDataLoss, "stage record index", err)
-		}
+	if err := s.stageRecordIndexReplace(batch, idx, old, oldFound); err != nil {
+		return err
 	}
 	if err := batch.Commit(pdb.Sync); err != nil {
 		return trusterr.Wrap(trusterr.CodeDataLoss, "commit proof bundle", err)
+	}
+	return nil
+}
+
+func (s *Store) PutRecordIndex(ctx context.Context, idx model.RecordIndex) error {
+	if err := ctx.Err(); err != nil {
+		return trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore put record index canceled", err)
+	}
+	if idx.RecordID == "" {
+		return trusterr.New(trusterr.CodeInvalidArgument, "record index record_id is required")
+	}
+	var old model.RecordIndex
+	oldFound, err := s.readCBOR(recordByIDKey(idx.RecordID), &old)
+	if err != nil {
+		return trusterr.Wrap(trusterr.CodeDataLoss, "read existing record index", err)
+	}
+	batch := s.db.NewBatch()
+	defer batch.Close()
+	if err := s.stageRecordIndexReplace(batch, idx, old, oldFound); err != nil {
+		return err
+	}
+	if err := batch.Commit(pdb.Sync); err != nil {
+		return trusterr.Wrap(trusterr.CodeDataLoss, "commit record index", err)
 	}
 	return nil
 }
@@ -451,6 +462,60 @@ func (s *Store) ListRootsAfter(ctx context.Context, afterClosedAtUnixN int64, li
 	}
 	if err := iter.Error(); err != nil {
 		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "iterate roots after", err)
+	}
+	return roots, nil
+}
+
+func (s *Store) ListRootsPage(ctx context.Context, opts model.RootListOptions) ([]model.BatchRoot, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list roots page canceled", err)
+	}
+	limit := normaliseRecordLimit(opts.Limit)
+	lower, upper := rootBounds()
+	iter, err := s.db.NewIter(&pdb.IterOptions{LowerBound: lower, UpperBound: upper})
+	if err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "open root iterator", err)
+	}
+	defer iter.Close()
+
+	desc := !strings.EqualFold(opts.Direction, model.RecordListDirectionAsc)
+	hasCursor := opts.AfterClosedAtUnixN != 0 || opts.AfterBatchID != ""
+	var ok bool
+	if desc {
+		if hasCursor {
+			ok = iter.SeekLT(rootKey(opts.AfterClosedAtUnixN, opts.AfterBatchID))
+		} else {
+			ok = iter.Last()
+		}
+	} else if hasCursor {
+		ok = iter.SeekGE(rootKey(opts.AfterClosedAtUnixN, opts.AfterBatchID))
+	} else {
+		ok = iter.First()
+	}
+
+	roots := make([]model.BatchRoot, 0, limit)
+	for ok {
+		if err := ctx.Err(); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list roots page canceled", err)
+		}
+		if len(roots) >= limit {
+			break
+		}
+		var root model.BatchRoot
+		if err := cborx.UnmarshalLimit(iter.Value(), &root, maxStoredObjectBytes); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "decode batch root", err)
+		}
+		if model.BatchRootAfterCursor(root, opts) {
+			roots = append(roots, root)
+		}
+		if desc {
+			ok = iter.Prev()
+		} else {
+			ok = iter.Next()
+		}
+	}
+	if err := iter.Error(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "iterate roots page", err)
 	}
 	return roots, nil
 }
@@ -906,6 +971,59 @@ func (s *Store) ListGlobalLeavesRange(ctx context.Context, startIndex uint64, li
 	return leaves, nil
 }
 
+func (s *Store) ListGlobalLeavesPage(ctx context.Context, opts model.GlobalLeafListOptions) ([]model.GlobalLogLeaf, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list global leaves page canceled", err)
+	}
+	limit := normaliseRecordLimit(opts.Limit)
+	lower, upper := prefixBounds(prefixGlobalLeaf)
+	iter, err := s.db.NewIter(&pdb.IterOptions{LowerBound: lower, UpperBound: upper})
+	if err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "open global leaf iterator", err)
+	}
+	defer iter.Close()
+
+	desc := !strings.EqualFold(opts.Direction, model.RecordListDirectionAsc)
+	var ok bool
+	if desc {
+		if opts.AfterLeafIndex > 0 {
+			ok = iter.SeekLT(globalLeafKey(opts.AfterLeafIndex))
+		} else {
+			ok = iter.Last()
+		}
+	} else if opts.AfterLeafIndex > 0 {
+		ok = iter.SeekGE(globalLeafKey(opts.AfterLeafIndex))
+	} else {
+		ok = iter.First()
+	}
+
+	leaves := make([]model.GlobalLogLeaf, 0, limit)
+	for ok {
+		if err := ctx.Err(); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list global leaves page canceled", err)
+		}
+		if len(leaves) >= limit {
+			break
+		}
+		var leaf model.GlobalLogLeaf
+		if err := cborx.UnmarshalLimit(iter.Value(), &leaf, maxStoredObjectBytes); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "decode global log leaf", err)
+		}
+		if model.Uint64AfterCursor(leaf.LeafIndex, opts.AfterLeafIndex, opts.Direction) {
+			leaves = append(leaves, leaf)
+		}
+		if desc {
+			ok = iter.Prev()
+		} else {
+			ok = iter.Next()
+		}
+	}
+	if err := iter.Error(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "iterate global leaves page", err)
+	}
+	return leaves, nil
+}
+
 func (s *Store) PutSignedTreeHead(ctx context.Context, sth model.SignedTreeHead) error {
 	if err := ctx.Err(); err != nil {
 		return trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore put sth canceled", err)
@@ -970,6 +1088,59 @@ func (s *Store) ListSignedTreeHeadsAfter(ctx context.Context, afterTreeSize uint
 	}
 	if err := iter.Error(); err != nil {
 		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "iterate sth after", err)
+	}
+	return sths, nil
+}
+
+func (s *Store) ListSignedTreeHeadsPage(ctx context.Context, opts model.TreeHeadListOptions) ([]model.SignedTreeHead, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list signed tree heads page canceled", err)
+	}
+	limit := normaliseRecordLimit(opts.Limit)
+	lower, upper := prefixBounds(prefixSTH)
+	iter, err := s.db.NewIter(&pdb.IterOptions{LowerBound: lower, UpperBound: upper})
+	if err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "open signed tree head iterator", err)
+	}
+	defer iter.Close()
+
+	desc := !strings.EqualFold(opts.Direction, model.RecordListDirectionAsc)
+	var ok bool
+	if desc {
+		if opts.AfterTreeSize > 0 {
+			ok = iter.SeekLT(sthKey(opts.AfterTreeSize))
+		} else {
+			ok = iter.Last()
+		}
+	} else if opts.AfterTreeSize > 0 {
+		ok = iter.SeekGE(sthKey(opts.AfterTreeSize))
+	} else {
+		ok = iter.First()
+	}
+
+	sths := make([]model.SignedTreeHead, 0, limit)
+	for ok {
+		if err := ctx.Err(); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list signed tree heads page canceled", err)
+		}
+		if len(sths) >= limit {
+			break
+		}
+		var sth model.SignedTreeHead
+		if err := cborx.UnmarshalLimit(iter.Value(), &sth, maxStoredObjectBytes); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "decode signed tree head", err)
+		}
+		if model.Uint64AfterCursor(sth.TreeSize, opts.AfterTreeSize, opts.Direction) {
+			sths = append(sths, sth)
+		}
+		if desc {
+			ok = iter.Prev()
+		} else {
+			ok = iter.Next()
+		}
+	}
+	if err := iter.Error(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "iterate signed tree heads page", err)
 	}
 	return sths, nil
 }
@@ -1213,7 +1384,10 @@ func (s *Store) MarkGlobalLogPublished(ctx context.Context, batchID string, sth 
 	item.LastAttemptUnixN = now
 	item.NextAttemptUnixN = 0
 	item.CompletedAtUnixN = now
-	return s.replaceGlobalLogOutbox(ctx, old, item)
+	if err := s.replaceGlobalLogOutbox(ctx, old, item); err != nil {
+		return err
+	}
+	return s.promoteBatchRecords(ctx, batchID, "L4")
 }
 
 func (s *Store) RescheduleGlobalLog(ctx context.Context, batchID string, attempts int, nextAttemptUnixN int64, lastErrorMessage string) error {
@@ -1370,6 +1544,59 @@ func (s *Store) ListSTHAnchorOutboxItemsAfter(ctx context.Context, afterTreeSize
 	return items, nil
 }
 
+func (s *Store) ListSTHAnchorsPage(ctx context.Context, opts model.AnchorListOptions) ([]model.STHAnchorOutboxItem, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list sth anchors page canceled", err)
+	}
+	limit := normaliseRecordLimit(opts.Limit)
+	lower, upper := prefixBounds(prefixAnchorOutbox)
+	iter, err := s.db.NewIter(&pdb.IterOptions{LowerBound: lower, UpperBound: upper})
+	if err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "open sth anchor outbox iterator", err)
+	}
+	defer iter.Close()
+
+	desc := !strings.EqualFold(opts.Direction, model.RecordListDirectionAsc)
+	var ok bool
+	if desc {
+		if opts.AfterTreeSize > 0 {
+			ok = iter.SeekLT(anchorOutboxKey(opts.AfterTreeSize))
+		} else {
+			ok = iter.Last()
+		}
+	} else if opts.AfterTreeSize > 0 {
+		ok = iter.SeekGE(anchorOutboxKey(opts.AfterTreeSize))
+	} else {
+		ok = iter.First()
+	}
+
+	items := make([]model.STHAnchorOutboxItem, 0, limit)
+	for ok {
+		if err := ctx.Err(); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list sth anchors page canceled", err)
+		}
+		if len(items) >= limit {
+			break
+		}
+		var item model.STHAnchorOutboxItem
+		if err := cborx.UnmarshalLimit(iter.Value(), &item, maxStoredObjectBytes); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "decode sth anchor outbox item", err)
+		}
+		if model.Uint64AfterCursor(item.TreeSize, opts.AfterTreeSize, opts.Direction) {
+			items = append(items, item)
+		}
+		if desc {
+			ok = iter.Prev()
+		} else {
+			ok = iter.Next()
+		}
+	}
+	if err := iter.Error(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "iterate sth anchors page", err)
+	}
+	return items, nil
+}
+
 func (s *Store) RescheduleSTHAnchor(ctx context.Context, treeSize uint64, attempts int, nextAttemptUnixN int64, lastErrorMessage string) error {
 	item, ok, err := s.GetSTHAnchorOutboxItem(ctx, treeSize)
 	if err != nil {
@@ -1438,7 +1665,14 @@ func (s *Store) MarkSTHAnchorPublished(ctx context.Context, result model.STHAnch
 	if err := batch.Commit(pdb.Sync); err != nil {
 		return trusterr.Wrap(trusterr.CodeDataLoss, "commit sth anchor published batch", err)
 	}
-	return nil
+	leaf, ok, err := s.GetGlobalLeaf(ctx, result.TreeSize-1)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	return s.promoteBatchRecords(ctx, leaf.BatchID, "L5")
 }
 
 func (s *Store) MarkSTHAnchorFailed(ctx context.Context, treeSize uint64, lastErrorMessage string) error {
@@ -1515,6 +1749,8 @@ func recordListPrefix(opts model.RecordListOptions) string {
 		return prefixRecordByToken + recordSecondaryPart(model.RecordStorageQueryToken(opts.Query)) + "/"
 	case opts.BatchID != "":
 		return prefixRecordByBatch + recordSecondaryPart(opts.BatchID) + "/"
+	case opts.ProofLevel != "":
+		return prefixRecordByLevel + recordSecondaryPart(opts.ProofLevel) + "/"
 	case opts.TenantID != "":
 		return prefixRecordByTenant + recordSecondaryPart(opts.TenantID) + "/"
 	case opts.ClientID != "":
@@ -1541,6 +1777,30 @@ func recordRangeExhausted(idx model.RecordIndex, opts model.RecordListOptions, d
 	return opts.ReceivedToUnixN > 0 && idx.ReceivedAtUnixN > opts.ReceivedToUnixN
 }
 
+func (s *Store) stageRecordIndexReplace(batch *pdb.Batch, idx, old model.RecordIndex, oldFound bool) error {
+	idx.ProofLevel = model.RecordIndexProofLevel(idx)
+	if idx.SchemaVersion == "" {
+		idx.SchemaVersion = model.SchemaRecordIndex
+	}
+	indexData, err := cborx.Marshal(idx)
+	if err != nil {
+		return trusterr.Wrap(trusterr.CodeDataLoss, "encode record index", err)
+	}
+	if oldFound {
+		for _, key := range recordIndexKeys(old) {
+			if err := batch.Delete(key, nil); err != nil {
+				return trusterr.Wrap(trusterr.CodeDataLoss, "stage old record index delete", err)
+			}
+		}
+	}
+	for _, key := range recordIndexKeys(idx) {
+		if err := batch.Set(key, indexData, nil); err != nil {
+			return trusterr.Wrap(trusterr.CodeDataLoss, "stage record index", err)
+		}
+	}
+	return nil
+}
+
 func (s *Store) replaceGlobalLogOutbox(ctx context.Context, old, next model.GlobalLogOutboxItem) error {
 	if err := ctx.Err(); err != nil {
 		return trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore update global log outbox canceled", err)
@@ -1564,6 +1824,35 @@ func (s *Store) replaceGlobalLogOutbox(ctx context.Context, old, next model.Glob
 	}
 	if err := batch.Commit(pdb.Sync); err != nil {
 		return trusterr.Wrap(trusterr.CodeDataLoss, "commit global log outbox update", err)
+	}
+	return nil
+}
+
+func (s *Store) promoteBatchRecords(ctx context.Context, batchID, proofLevel string) error {
+	if batchID == "" {
+		return nil
+	}
+	prefix := prefixRecordByBatch + recordSecondaryPart(batchID) + "/"
+	updates := make([]model.RecordIndex, 0, 16)
+	err := s.scanPrefix(ctx, prefix, func(value []byte) error {
+		var idx model.RecordIndex
+		if err := cborx.UnmarshalLimit(value, &idx, maxStoredObjectBytes); err != nil {
+			return err
+		}
+		if model.ProofLevelRank(model.RecordIndexProofLevel(idx)) >= model.ProofLevelRank(proofLevel) {
+			return nil
+		}
+		idx.ProofLevel = proofLevel
+		updates = append(updates, idx)
+		return nil
+	})
+	if err != nil {
+		return trusterr.Wrap(trusterr.CodeDataLoss, "scan batch record indexes", err)
+	}
+	for _, idx := range updates {
+		if err := s.PutRecordIndex(ctx, idx); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/proofstore/proofstoretest/conformance.go
+++ b/internal/proofstore/proofstoretest/conformance.go
@@ -28,20 +28,25 @@ func RunConformance(t *testing.T, newStore Factory) {
 	t.Run("BundleNotFound", func(t *testing.T) { testBundleNotFound(t, newStore) })
 	t.Run("BundleOverwrite", func(t *testing.T) { testBundleOverwrite(t, newStore) })
 	t.Run("RecordIndexListAndFilters", func(t *testing.T) { testRecordIndexListAndFilters(t, newStore) })
+	t.Run("RecordIndexProofLevelPromotes", func(t *testing.T) { testRecordIndexProofLevelPromotes(t, newStore) })
 	t.Run("ManifestRoundTrip", func(t *testing.T) { testManifestRoundTrip(t, newStore) })
 	t.Run("ManifestListIsSorted", func(t *testing.T) { testManifestListIsSorted(t, newStore) })
 	t.Run("ManifestListAfterPaginates", func(t *testing.T) { testManifestListAfterPaginates(t, newStore) })
 	t.Run("RootListIsReverseChrono", func(t *testing.T) { testRootListIsReverseChrono(t, newStore) })
 	t.Run("RootListAcceptsHugeLimit", func(t *testing.T) { testRootListAcceptsHugeLimit(t, newStore) })
 	t.Run("LatestRootSelectsNewest", func(t *testing.T) { testLatestRoot(t, newStore) })
+	t.Run("RootListPagePaginates", func(t *testing.T) { testRootListPagePaginates(t, newStore) })
 	t.Run("CheckpointRoundTrip", func(t *testing.T) { testCheckpointRoundTrip(t, newStore) })
 	t.Run("CheckpointMissing", func(t *testing.T) { testCheckpointMissing(t, newStore) })
 	t.Run("ConcurrentPutBundle", func(t *testing.T) { testConcurrentPutBundle(t, newStore) })
 	t.Run("GlobalLogRoundTrip", func(t *testing.T) { testGlobalLogRoundTrip(t, newStore) })
 	t.Run("GlobalLogPagedStateRoundTrip", func(t *testing.T) { testGlobalLogPagedStateRoundTrip(t, newStore) })
+	t.Run("GlobalLeafListPagePaginates", func(t *testing.T) { testGlobalLeafListPagePaginates(t, newStore) })
 	t.Run("GlobalLogTileRoundTrip", func(t *testing.T) { testGlobalLogTileRoundTrip(t, newStore) })
 	t.Run("GlobalLogTileListAfterPaginates", func(t *testing.T) { testGlobalLogTileListAfterPaginates(t, newStore) })
 	t.Run("STHAnchorEnqueueIsIdempotent", func(t *testing.T) { testSTHAnchorEnqueueIsIdempotent(t, newStore) })
+	t.Run("SignedTreeHeadListPagePaginates", func(t *testing.T) { testSignedTreeHeadListPagePaginates(t, newStore) })
+	t.Run("STHAnchorListPagePaginates", func(t *testing.T) { testSTHAnchorListPagePaginates(t, newStore) })
 	t.Run("STHAnchorListAfterPaginates", func(t *testing.T) { testSTHAnchorListAfterPaginates(t, newStore) })
 	t.Run("STHAnchorListPendingRespectsBackoff", func(t *testing.T) { testSTHAnchorListPendingRespectsBackoff(t, newStore) })
 	t.Run("STHAnchorListPendingIsCommitOrdered", func(t *testing.T) { testSTHAnchorListPendingIsCommitOrdered(t, newStore) })
@@ -183,6 +188,65 @@ func testRecordIndexListAndFilters(t *testing.T, newStore Factory) {
 	}
 	if len(byRange) != 1 || byRange[0].RecordID != "rec-2" {
 		t.Fatalf("range page = %+v", byRange)
+	}
+}
+
+func testRecordIndexProofLevelPromotes(t *testing.T, newStore Factory) {
+	t.Parallel()
+	store, cleanup := newStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	bundle := recordBundle("rec-1", "tenant-a", "client-a", "batch-1", 100)
+	if err := store.PutBundle(ctx, bundle); err != nil {
+		t.Fatalf("PutBundle: %v", err)
+	}
+	if err := store.PutGlobalLeaf(ctx, model.GlobalLogLeaf{
+		SchemaVersion: model.SchemaGlobalLogLeaf,
+		BatchID:       "batch-1",
+		BatchRoot:     []byte{1},
+		LeafIndex:     0,
+	}); err != nil {
+		t.Fatalf("PutGlobalLeaf: %v", err)
+	}
+	sth := model.SignedTreeHead{SchemaVersion: model.SchemaSignedTreeHead, TreeSize: 1, RootHash: []byte{1}}
+	if err := store.EnqueueGlobalLog(ctx, model.GlobalLogOutboxItem{
+		SchemaVersion: model.SchemaGlobalLogOutbox,
+		BatchID:       "batch-1",
+		BatchRoot:     model.BatchRoot{SchemaVersion: model.SchemaBatchRoot, BatchID: "batch-1", BatchRoot: []byte{1}, TreeSize: 1},
+		Status:        model.AnchorStatePending,
+	}); err != nil {
+		t.Fatalf("EnqueueGlobalLog: %v", err)
+	}
+	if err := store.MarkGlobalLogPublished(ctx, "batch-1", sth); err != nil {
+		t.Fatalf("MarkGlobalLogPublished: %v", err)
+	}
+	idx, ok, err := store.GetRecordIndex(ctx, "rec-1")
+	if err != nil || !ok {
+		t.Fatalf("GetRecordIndex L4 ok=%v err=%v", ok, err)
+	}
+	if level := model.RecordIndexProofLevel(idx); level != "L4" {
+		t.Fatalf("proof level after global publish = %s, want L4", level)
+	}
+	if err := store.EnqueueSTHAnchor(ctx, sthAnchorItem(1, "ots", 100)); err != nil {
+		t.Fatalf("EnqueueSTHAnchor: %v", err)
+	}
+	if err := store.MarkSTHAnchorPublished(ctx, sthAnchorResult(1, "ots", "anchor-1")); err != nil {
+		t.Fatalf("MarkSTHAnchorPublished: %v", err)
+	}
+	idx, ok, err = store.GetRecordIndex(ctx, "rec-1")
+	if err != nil || !ok {
+		t.Fatalf("GetRecordIndex L5 ok=%v err=%v", ok, err)
+	}
+	if level := model.RecordIndexProofLevel(idx); level != "L5" {
+		t.Fatalf("proof level after anchor publish = %s, want L5", level)
+	}
+	byLevel, err := store.ListRecordIndexes(ctx, model.RecordListOptions{ProofLevel: "L5", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListRecordIndexes level: %v", err)
+	}
+	if len(byLevel) != 1 || byLevel[0].RecordID != "rec-1" {
+		t.Fatalf("ListRecordIndexes level page = %+v", byLevel)
 	}
 }
 
@@ -354,6 +418,42 @@ func testLatestRoot(t *testing.T, newStore Factory) {
 	}
 	if got.ClosedAtUnixN != 300 {
 		t.Fatalf("LatestRoot ts = %d, want 300", got.ClosedAtUnixN)
+	}
+}
+
+func testRootListPagePaginates(t *testing.T, newStore Factory) {
+	t.Parallel()
+	store, cleanup := newStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	for _, root := range []model.BatchRoot{
+		{SchemaVersion: model.SchemaBatchRoot, BatchID: "batch-1", ClosedAtUnixN: 100},
+		{SchemaVersion: model.SchemaBatchRoot, BatchID: "batch-2", ClosedAtUnixN: 200},
+		{SchemaVersion: model.SchemaBatchRoot, BatchID: "batch-3", ClosedAtUnixN: 300},
+	} {
+		if err := store.PutRoot(ctx, root); err != nil {
+			t.Fatalf("PutRoot %s: %v", root.BatchID, err)
+		}
+	}
+	first, err := store.ListRootsPage(ctx, model.RootListOptions{Limit: 2, Direction: model.RecordListDirectionDesc})
+	if err != nil {
+		t.Fatalf("ListRootsPage first: %v", err)
+	}
+	if len(first) != 2 || first[0].BatchID != "batch-3" || first[1].BatchID != "batch-2" {
+		t.Fatalf("first roots page = %+v", first)
+	}
+	next, err := store.ListRootsPage(ctx, model.RootListOptions{
+		Limit:              2,
+		Direction:          model.RecordListDirectionDesc,
+		AfterClosedAtUnixN: first[1].ClosedAtUnixN,
+		AfterBatchID:       first[1].BatchID,
+	})
+	if err != nil {
+		t.Fatalf("ListRootsPage next: %v", err)
+	}
+	if len(next) != 1 || next[0].BatchID != "batch-1" {
+		t.Fatalf("next roots page = %+v", next)
 	}
 }
 
@@ -603,6 +703,77 @@ func testGlobalLogPagedStateRoundTrip(t *testing.T, newStore Factory) {
 	}
 }
 
+func testGlobalLeafListPagePaginates(t *testing.T, newStore Factory) {
+	t.Parallel()
+	store, cleanup := newStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	for i := uint64(0); i < 3; i++ {
+		if err := store.PutGlobalLeaf(ctx, model.GlobalLogLeaf{
+			SchemaVersion: model.SchemaGlobalLogLeaf,
+			BatchID:       "batch-" + itoa(int(i+1)),
+			LeafIndex:     i,
+			LeafHash:      []byte{byte(i + 1)},
+		}); err != nil {
+			t.Fatalf("PutGlobalLeaf %d: %v", i, err)
+		}
+	}
+	first, err := store.ListGlobalLeavesPage(ctx, model.GlobalLeafListOptions{Limit: 2, Direction: model.RecordListDirectionDesc})
+	if err != nil {
+		t.Fatalf("ListGlobalLeavesPage first: %v", err)
+	}
+	if len(first) != 2 || first[0].LeafIndex != 2 || first[1].LeafIndex != 1 {
+		t.Fatalf("first global leaf page = %+v", first)
+	}
+	next, err := store.ListGlobalLeavesPage(ctx, model.GlobalLeafListOptions{
+		Limit:          2,
+		Direction:      model.RecordListDirectionDesc,
+		AfterLeafIndex: first[1].LeafIndex,
+	})
+	if err != nil {
+		t.Fatalf("ListGlobalLeavesPage next: %v", err)
+	}
+	if len(next) != 1 || next[0].LeafIndex != 0 {
+		t.Fatalf("next global leaf page = %+v", next)
+	}
+}
+
+func testSignedTreeHeadListPagePaginates(t *testing.T, newStore Factory) {
+	t.Parallel()
+	store, cleanup := newStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	for _, size := range []uint64{1, 2, 3} {
+		if err := store.PutSignedTreeHead(ctx, model.SignedTreeHead{
+			SchemaVersion: model.SchemaSignedTreeHead,
+			TreeSize:      size,
+			RootHash:      []byte{byte(size)},
+		}); err != nil {
+			t.Fatalf("PutSignedTreeHead %d: %v", size, err)
+		}
+	}
+	first, err := store.ListSignedTreeHeadsPage(ctx, model.TreeHeadListOptions{Limit: 2, Direction: model.RecordListDirectionDesc})
+	if err != nil {
+		t.Fatalf("ListSignedTreeHeadsPage first: %v", err)
+	}
+	if len(first) != 2 || first[0].TreeSize != 3 || first[1].TreeSize != 2 {
+		t.Fatalf("first sth page = %+v", first)
+	}
+	next, err := store.ListSignedTreeHeadsPage(ctx, model.TreeHeadListOptions{
+		Limit:         2,
+		Direction:     model.RecordListDirectionDesc,
+		AfterTreeSize: first[1].TreeSize,
+	})
+	if err != nil {
+		t.Fatalf("ListSignedTreeHeadsPage next: %v", err)
+	}
+	if len(next) != 1 || next[0].TreeSize != 1 {
+		t.Fatalf("next sth page = %+v", next)
+	}
+}
+
 func testGlobalLogTileListAfterPaginates(t *testing.T, newStore Factory) {
 	t.Parallel()
 	store, cleanup := newStore(t)
@@ -677,6 +848,37 @@ func testSTHAnchorEnqueueIsIdempotent(t *testing.T, newStore Factory) {
 	}
 	if got := trusterr.CodeOf(err); got != trusterr.CodeAlreadyExists {
 		t.Fatalf("CodeOf(err) = %s, want %s", got, trusterr.CodeAlreadyExists)
+	}
+}
+
+func testSTHAnchorListPagePaginates(t *testing.T, newStore Factory) {
+	t.Parallel()
+	store, cleanup := newStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	for _, size := range []uint64{1, 2, 3} {
+		if err := store.EnqueueSTHAnchor(ctx, sthAnchorItem(size, "ots", int64(size))); err != nil {
+			t.Fatalf("EnqueueSTHAnchor %d: %v", size, err)
+		}
+	}
+	first, err := store.ListSTHAnchorsPage(ctx, model.AnchorListOptions{Limit: 2, Direction: model.RecordListDirectionDesc})
+	if err != nil {
+		t.Fatalf("ListSTHAnchorsPage first: %v", err)
+	}
+	if len(first) != 2 || first[0].TreeSize != 3 || first[1].TreeSize != 2 {
+		t.Fatalf("first anchor page = %+v", first)
+	}
+	next, err := store.ListSTHAnchorsPage(ctx, model.AnchorListOptions{
+		Limit:         2,
+		Direction:     model.RecordListDirectionDesc,
+		AfterTreeSize: first[1].TreeSize,
+	})
+	if err != nil {
+		t.Fatalf("ListSTHAnchorsPage next: %v", err)
+	}
+	if len(next) != 1 || next[0].TreeSize != 1 {
+		t.Fatalf("next anchor page = %+v", next)
 	}
 }
 

--- a/internal/proofstore/store.go
+++ b/internal/proofstore/store.go
@@ -21,11 +21,13 @@ import (
 type Store interface {
 	PutBundle(ctx context.Context, bundle model.ProofBundle) error
 	GetBundle(ctx context.Context, recordID string) (model.ProofBundle, error)
+	PutRecordIndex(ctx context.Context, idx model.RecordIndex) error
 	GetRecordIndex(ctx context.Context, recordID string) (model.RecordIndex, bool, error)
 	ListRecordIndexes(ctx context.Context, opts model.RecordListOptions) ([]model.RecordIndex, error)
 	PutRoot(ctx context.Context, root model.BatchRoot) error
 	ListRoots(ctx context.Context, limit int) ([]model.BatchRoot, error)
 	ListRootsAfter(ctx context.Context, afterClosedAtUnixN int64, limit int) ([]model.BatchRoot, error)
+	ListRootsPage(ctx context.Context, opts model.RootListOptions) ([]model.BatchRoot, error)
 	LatestRoot(ctx context.Context) (model.BatchRoot, error)
 	PutManifest(ctx context.Context, manifest model.BatchManifest) error
 	GetManifest(ctx context.Context, batchID string) (model.BatchManifest, error)
@@ -39,6 +41,7 @@ type Store interface {
 	GetGlobalLeafByBatchID(ctx context.Context, batchID string) (model.GlobalLogLeaf, bool, error)
 	ListGlobalLeaves(ctx context.Context) ([]model.GlobalLogLeaf, error)
 	ListGlobalLeavesRange(ctx context.Context, startIndex uint64, limit int) ([]model.GlobalLogLeaf, error)
+	ListGlobalLeavesPage(ctx context.Context, opts model.GlobalLeafListOptions) ([]model.GlobalLogLeaf, error)
 	PutGlobalLogNode(ctx context.Context, node model.GlobalLogNode) error
 	GetGlobalLogNode(ctx context.Context, level, startIndex uint64) (model.GlobalLogNode, bool, error)
 	// ListGlobalLogNodesAfter returns nodes in (level,start_index) order.
@@ -50,6 +53,7 @@ type Store interface {
 	PutSignedTreeHead(ctx context.Context, sth model.SignedTreeHead) error
 	GetSignedTreeHead(ctx context.Context, treeSize uint64) (model.SignedTreeHead, bool, error)
 	ListSignedTreeHeadsAfter(ctx context.Context, afterTreeSize uint64, limit int) ([]model.SignedTreeHead, error)
+	ListSignedTreeHeadsPage(ctx context.Context, opts model.TreeHeadListOptions) ([]model.SignedTreeHead, error)
 	LatestSignedTreeHead(ctx context.Context) (model.SignedTreeHead, bool, error)
 	PutGlobalLogTile(ctx context.Context, tile model.GlobalLogTile) error
 	ListGlobalLogTiles(ctx context.Context) ([]model.GlobalLogTile, error)
@@ -73,6 +77,7 @@ type Store interface {
 	ListPendingSTHAnchors(ctx context.Context, nowUnixN int64, limit int) ([]model.STHAnchorOutboxItem, error)
 	ListPublishedSTHAnchors(ctx context.Context, limit int) ([]model.STHAnchorOutboxItem, error)
 	ListSTHAnchorOutboxItemsAfter(ctx context.Context, afterTreeSize uint64, limit int) ([]model.STHAnchorOutboxItem, error)
+	ListSTHAnchorsPage(ctx context.Context, opts model.AnchorListOptions) ([]model.STHAnchorOutboxItem, error)
 	GetSTHAnchorOutboxItem(ctx context.Context, treeSize uint64) (model.STHAnchorOutboxItem, bool, error)
 	RescheduleSTHAnchor(ctx context.Context, treeSize uint64, attempts int, nextAttemptUnixN int64, lastErrorMessage string) error
 	MarkSTHAnchorPublished(ctx context.Context, result model.STHAnchorResult) error

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -21,10 +21,14 @@ type Transport interface {
 	SubmitSignedClaim(context.Context, SignedClaim) (SubmitResult, error)
 	GetRecord(context.Context, string) (RecordIndex, error)
 	ListRecords(context.Context, ListRecordsOptions) (RecordPage, error)
+	ListRootsPage(context.Context, ListPageOptions) (RootPage, error)
 	GetProofBundle(context.Context, string) (ProofBundle, error)
 	ListRoots(context.Context, int) ([]BatchRoot, error)
 	LatestRoot(context.Context) (BatchRoot, error)
+	ListSTHs(context.Context, ListPageOptions) (TreeHeadPage, error)
 	GetGlobalProof(context.Context, string) (GlobalLogProof, error)
+	ListGlobalLeaves(context.Context, ListPageOptions) (GlobalLeafPage, error)
+	ListAnchors(context.Context, ListPageOptions) (AnchorPage, error)
 	GetAnchor(context.Context, uint64) (AnchorStatus, error)
 	LatestSTH(context.Context) (SignedTreeHead, error)
 	GetSTH(context.Context, uint64) (SignedTreeHead, error)
@@ -132,8 +136,16 @@ func (c *Client) ListRecords(ctx context.Context, opts ListRecordsOptions) (Reco
 	return c.transport.ListRecords(ctx, opts)
 }
 
+func (c *Client) ListRootsPage(ctx context.Context, opts ListPageOptions) (RootPage, error) {
+	return c.transport.ListRootsPage(ctx, opts)
+}
+
 func (c *Client) ListRoots(ctx context.Context, limit int) ([]BatchRoot, error) {
-	return c.transport.ListRoots(ctx, limit)
+	page, err := c.transport.ListRootsPage(ctx, ListPageOptions{Limit: limit, Direction: RecordListDirectionDesc})
+	if err != nil {
+		return nil, err
+	}
+	return page.Roots, nil
 }
 
 func (c *Client) LatestRoot(ctx context.Context) (BatchRoot, error) {
@@ -146,6 +158,18 @@ func (c *Client) GetProofBundle(ctx context.Context, recordID string) (ProofBund
 
 func (c *Client) GetGlobalProof(ctx context.Context, batchID string) (GlobalLogProof, error) {
 	return c.transport.GetGlobalProof(ctx, batchID)
+}
+
+func (c *Client) ListSTHs(ctx context.Context, opts ListPageOptions) (TreeHeadPage, error) {
+	return c.transport.ListSTHs(ctx, opts)
+}
+
+func (c *Client) ListGlobalLeaves(ctx context.Context, opts ListPageOptions) (GlobalLeafPage, error) {
+	return c.transport.ListGlobalLeaves(ctx, opts)
+}
+
+func (c *Client) ListAnchors(ctx context.Context, opts ListPageOptions) (AnchorPage, error) {
+	return c.transport.ListAnchors(ctx, opts)
 }
 
 func (c *Client) GetAnchor(ctx context.Context, treeSize uint64) (AnchorStatus, error) {

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -86,6 +86,7 @@ func TestClientListRecordsEncodesQuery(t *testing.T) {
 		if query.Get("limit") != "25" ||
 			query.Get("direction") != "asc" ||
 			query.Get("batch_id") != "batch-1" ||
+			query.Get("level") != "L4" ||
 			query.Get("q") != "hello" {
 			t.Fatalf("query = %s", r.URL.RawQuery)
 		}
@@ -107,10 +108,11 @@ func TestClientListRecordsEncodesQuery(t *testing.T) {
 		t.Fatalf("NewClient: %v", err)
 	}
 	page, err := client.ListRecords(context.Background(), ListRecordsOptions{
-		Limit:     25,
-		Direction: RecordListDirectionAsc,
-		BatchID:   "batch-1",
-		Query:     "hello",
+		Limit:      25,
+		Direction:  RecordListDirectionAsc,
+		BatchID:    "batch-1",
+		ProofLevel: "L4",
+		Query:      "hello",
 	})
 	if err != nil {
 		t.Fatalf("ListRecords: %v", err)
@@ -128,14 +130,33 @@ func TestClientOperationalEndpoints(t *testing.T) {
 		case "/healthz":
 			writeJSONForTest(t, w, http.StatusOK, map[string]bool{"ok": true})
 		case "/v1/roots":
-			if r.URL.Query().Get("limit") != "7" {
+			if r.URL.Query().Get("limit") != "7" || r.URL.Query().Get("direction") != "desc" {
 				t.Fatalf("roots query = %s", r.URL.RawQuery)
 			}
 			writeJSONForTest(t, w, http.StatusOK, rootsEnvelope{Roots: []BatchRoot{{
 				SchemaVersion: model.SchemaBatchRoot,
 				BatchID:       "batch-1",
 				TreeSize:      1,
-			}}})
+			}}, Limit: 7, Direction: "desc", NextCursor: "root-next"})
+		case "/v1/sth":
+			writeJSONForTest(t, w, http.StatusOK, sthsEnvelope{
+				STHs:  []SignedTreeHead{{SchemaVersion: model.SchemaSignedTreeHead, TreeSize: 4, RootHash: []byte{4}}},
+				Limit: 5, Direction: "desc", NextCursor: "sth-next",
+			})
+		case "/v1/global-log/leaves":
+			writeJSONForTest(t, w, http.StatusOK, globalLeavesEnvelope{
+				Leaves: []model.GlobalLogLeaf{{SchemaVersion: model.SchemaGlobalLogLeaf, BatchID: "batch-1", LeafIndex: 3}},
+				Limit:  5, Direction: "desc", NextCursor: "leaf-next",
+			})
+		case "/v1/anchors/sth":
+			writeJSONForTest(t, w, http.StatusOK, anchorsEnvelope{
+				Anchors: []anchorEnvelope{{
+					TreeSize: 4,
+					Status:   "published",
+					Result:   &STHAnchorResult{SchemaVersion: model.SchemaSTHAnchorResult, TreeSize: 4, AnchorID: "anchor-4"},
+				}},
+				Limit: 5, Direction: "desc", NextCursor: "anchor-next",
+			})
 		case "/v1/roots/latest":
 			writeJSONForTest(t, w, http.StatusOK, BatchRoot{
 				SchemaVersion: model.SchemaBatchRoot,
@@ -165,12 +186,40 @@ func TestClientOperationalEndpoints(t *testing.T) {
 	if len(roots) != 1 || roots[0].BatchID != "batch-1" {
 		t.Fatalf("roots = %+v", roots)
 	}
+	rootPage, err := client.ListRootsPage(context.Background(), ListPageOptions{Limit: 7, Direction: RecordListDirectionDesc})
+	if err != nil {
+		t.Fatalf("ListRootsPage: %v", err)
+	}
+	if rootPage.NextCursor != "root-next" || len(rootPage.Roots) != 1 {
+		t.Fatalf("root page = %+v", rootPage)
+	}
 	latest, err := client.LatestRoot(context.Background())
 	if err != nil {
 		t.Fatalf("LatestRoot: %v", err)
 	}
 	if latest.BatchID != "batch-latest" {
 		t.Fatalf("latest = %+v", latest)
+	}
+	sths, err := client.ListSTHs(context.Background(), ListPageOptions{Limit: 5})
+	if err != nil {
+		t.Fatalf("ListSTHs: %v", err)
+	}
+	if len(sths.STHs) != 1 || sths.NextCursor != "sth-next" {
+		t.Fatalf("sths = %+v", sths)
+	}
+	leaves, err := client.ListGlobalLeaves(context.Background(), ListPageOptions{Limit: 5})
+	if err != nil {
+		t.Fatalf("ListGlobalLeaves: %v", err)
+	}
+	if len(leaves.Leaves) != 1 || leaves.NextCursor != "leaf-next" {
+		t.Fatalf("leaves = %+v", leaves)
+	}
+	anchors, err := client.ListAnchors(context.Background(), ListPageOptions{Limit: 5})
+	if err != nil {
+		t.Fatalf("ListAnchors: %v", err)
+	}
+	if len(anchors.Anchors) != 1 || anchors.NextCursor != "anchor-next" || anchors.Anchors[0].TreeSize != 4 {
+		t.Fatalf("anchors = %+v", anchors)
 	}
 	metrics, err := client.MetricsRaw(context.Background())
 	if err != nil {

--- a/sdk/grpc_transport.go
+++ b/sdk/grpc_transport.go
@@ -148,6 +148,7 @@ func (t *grpcTransport) ListRecords(ctx context.Context, opts ListRecordsOptions
 		BatchID:           opts.BatchID,
 		TenantID:          opts.TenantID,
 		ClientID:          opts.ClientID,
+		ProofLevel:        opts.ProofLevel,
 		Query:             opts.Query,
 		ContentHashHex:    opts.ContentHashHex,
 		ReceivedFromUnixN: opts.ReceivedFromUnixN,
@@ -170,12 +171,21 @@ func (t *grpcTransport) GetProofBundle(ctx context.Context, recordID string) (Pr
 	return out.ProofBundle, nil
 }
 
-func (t *grpcTransport) ListRoots(ctx context.Context, limit int) ([]BatchRoot, error) {
+func (t *grpcTransport) ListRootsPage(ctx context.Context, opts ListPageOptions) (RootPage, error) {
 	var out grpcapi.ListRootsResponse
-	if err := t.invoke(ctx, grpcapi.FullMethodListRoots, &grpcapi.ListRootsRequest{Limit: limit}, &out); err != nil {
+	in := grpcapi.ListRootsRequest{Limit: opts.Limit, Direction: opts.Direction, Cursor: opts.Cursor}
+	if err := t.invoke(ctx, grpcapi.FullMethodListRoots, &in, &out); err != nil {
+		return RootPage{}, err
+	}
+	return RootPage{Roots: out.Roots, Limit: out.Limit, Direction: out.Direction, NextCursor: out.NextCursor}, nil
+}
+
+func (t *grpcTransport) ListRoots(ctx context.Context, limit int) ([]BatchRoot, error) {
+	page, err := t.ListRootsPage(ctx, ListPageOptions{Limit: limit, Direction: RecordListDirectionDesc})
+	if err != nil {
 		return nil, err
 	}
-	return out.Roots, nil
+	return page.Roots, nil
 }
 
 func (t *grpcTransport) LatestRoot(ctx context.Context) (BatchRoot, error) {
@@ -192,6 +202,42 @@ func (t *grpcTransport) GetGlobalProof(ctx context.Context, batchID string) (Glo
 		return GlobalLogProof{}, err
 	}
 	return out.Proof, nil
+}
+
+func (t *grpcTransport) ListSTHs(ctx context.Context, opts ListPageOptions) (TreeHeadPage, error) {
+	var out grpcapi.ListSTHsResponse
+	in := grpcapi.ListSTHsRequest{Limit: opts.Limit, Direction: opts.Direction, Cursor: opts.Cursor}
+	if err := t.invoke(ctx, grpcapi.FullMethodListSTHs, &in, &out); err != nil {
+		return TreeHeadPage{}, err
+	}
+	return TreeHeadPage{STHs: out.STHs, Limit: out.Limit, Direction: out.Direction, NextCursor: out.NextCursor}, nil
+}
+
+func (t *grpcTransport) ListGlobalLeaves(ctx context.Context, opts ListPageOptions) (GlobalLeafPage, error) {
+	var out grpcapi.ListGlobalLeavesResponse
+	in := grpcapi.ListGlobalLeavesRequest{Limit: opts.Limit, Direction: opts.Direction, Cursor: opts.Cursor}
+	if err := t.invoke(ctx, grpcapi.FullMethodListGlobalLeaves, &in, &out); err != nil {
+		return GlobalLeafPage{}, err
+	}
+	return GlobalLeafPage{Leaves: out.Leaves, Limit: out.Limit, Direction: out.Direction, NextCursor: out.NextCursor}, nil
+}
+
+func (t *grpcTransport) ListAnchors(ctx context.Context, opts ListPageOptions) (AnchorPage, error) {
+	var out grpcapi.ListAnchorsResponse
+	in := grpcapi.ListAnchorsRequest{Limit: opts.Limit, Direction: opts.Direction, Cursor: opts.Cursor}
+	if err := t.invoke(ctx, grpcapi.FullMethodListAnchors, &in, &out); err != nil {
+		return AnchorPage{}, err
+	}
+	items := make([]AnchorPageItem, 0, len(out.Anchors))
+	for _, item := range out.Anchors {
+		items = append(items, AnchorPageItem{
+			TreeSize: item.TreeSize,
+			Status:   item.Status,
+			Result:   item.Result,
+			Outbox:   item.Outbox,
+		})
+	}
+	return AnchorPage{Anchors: items, Limit: out.Limit, Direction: out.Direction, NextCursor: out.NextCursor}, nil
 }
 
 func (t *grpcTransport) GetAnchor(ctx context.Context, treeSize uint64) (AnchorStatus, error) {

--- a/sdk/grpc_transport_test.go
+++ b/sdk/grpc_transport_test.go
@@ -150,6 +150,10 @@ func (grpcTestBatch) RootsAfter(context.Context, int64, int) ([]model.BatchRoot,
 	return []model.BatchRoot{{SchemaVersion: model.SchemaBatchRoot, BatchID: "batch-2", TreeSize: 2, ClosedAtUnixN: 20}}, nil
 }
 
+func (grpcTestBatch) RootsPage(context.Context, model.RootListOptions) ([]model.BatchRoot, error) {
+	return []model.BatchRoot{{SchemaVersion: model.SchemaBatchRoot, BatchID: "batch-1", TreeSize: 1, ClosedAtUnixN: 10}}, nil
+}
+
 func (grpcTestBatch) LatestRoot(context.Context) (model.BatchRoot, error) {
 	return model.BatchRoot{SchemaVersion: model.SchemaBatchRoot, BatchID: "batch-latest", TreeSize: 3}, nil
 }

--- a/sdk/http_transport.go
+++ b/sdk/http_transport.go
@@ -95,6 +95,7 @@ func (t *httpTransport) ListRecords(ctx context.Context, opts ListRecordsOptions
 	setQuery(values, "batch_id", opts.BatchID)
 	setQuery(values, "tenant_id", opts.TenantID)
 	setQuery(values, "client_id", opts.ClientID)
+	setQuery(values, "level", opts.ProofLevel)
 	setQuery(values, "q", opts.Query)
 	setQuery(values, "content_hash", opts.ContentHashHex)
 	if opts.ReceivedFromUnixN > 0 {
@@ -112,19 +113,57 @@ func (t *httpTransport) ListRecords(ctx context.Context, opts ListRecordsOptions
 	return RecordPage{Records: records, Limit: env.Limit, Direction: env.Direction, NextCursor: env.NextCursor}, nil
 }
 
-func (t *httpTransport) ListRoots(ctx context.Context, limit int) ([]BatchRoot, error) {
-	if limit <= 0 {
-		limit = 100
-	}
-	values := url.Values{}
-	values.Set("limit", strconv.Itoa(limit))
+func (t *httpTransport) ListRootsPage(ctx context.Context, opts ListPageOptions) (RootPage, error) {
+	values := pageValues(opts)
 	var env rootsEnvelope
 	if err := t.getJSON(ctx, "/v1/roots", values, &env); err != nil {
+		return RootPage{}, err
+	}
+	return RootPage{Roots: env.Roots, Limit: env.Limit, Direction: env.Direction, NextCursor: env.NextCursor}, nil
+}
+
+func (t *httpTransport) ListRoots(ctx context.Context, limit int) ([]BatchRoot, error) {
+	page, err := t.ListRootsPage(ctx, ListPageOptions{Limit: limit, Direction: model.RecordListDirectionDesc})
+	if err != nil {
 		return nil, err
 	}
-	roots := make([]BatchRoot, 0, len(env.Roots))
-	roots = append(roots, env.Roots...)
-	return roots, nil
+	return page.Roots, nil
+}
+
+func (t *httpTransport) ListSTHs(ctx context.Context, opts ListPageOptions) (TreeHeadPage, error) {
+	values := pageValues(opts)
+	var env sthsEnvelope
+	if err := t.getJSON(ctx, "/v1/sth", values, &env); err != nil {
+		return TreeHeadPage{}, err
+	}
+	return TreeHeadPage{STHs: env.STHs, Limit: env.Limit, Direction: env.Direction, NextCursor: env.NextCursor}, nil
+}
+
+func (t *httpTransport) ListGlobalLeaves(ctx context.Context, opts ListPageOptions) (GlobalLeafPage, error) {
+	values := pageValues(opts)
+	var env globalLeavesEnvelope
+	if err := t.getJSON(ctx, "/v1/global-log/leaves", values, &env); err != nil {
+		return GlobalLeafPage{}, err
+	}
+	return GlobalLeafPage{Leaves: env.Leaves, Limit: env.Limit, Direction: env.Direction, NextCursor: env.NextCursor}, nil
+}
+
+func (t *httpTransport) ListAnchors(ctx context.Context, opts ListPageOptions) (AnchorPage, error) {
+	values := pageValues(opts)
+	var env anchorsEnvelope
+	if err := t.getJSON(ctx, "/v1/anchors/sth", values, &env); err != nil {
+		return AnchorPage{}, err
+	}
+	items := make([]AnchorPageItem, 0, len(env.Anchors))
+	for _, item := range env.Anchors {
+		items = append(items, AnchorPageItem{
+			TreeSize: item.TreeSize,
+			Status:   item.Status,
+			Result:   item.Result,
+			Outbox:   item.Outbox,
+		})
+	}
+	return AnchorPage{Anchors: items, Limit: env.Limit, Direction: env.Direction, NextCursor: env.NextCursor}, nil
 }
 
 func (t *httpTransport) LatestRoot(ctx context.Context) (BatchRoot, error) {
@@ -260,6 +299,22 @@ func setQuery(values url.Values, name, value string) {
 	}
 }
 
+func pageValues(opts ListPageOptions) url.Values {
+	values := url.Values{}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	values.Set("limit", strconv.Itoa(limit))
+	direction := opts.Direction
+	if direction == "" {
+		direction = model.RecordListDirectionDesc
+	}
+	values.Set("direction", direction)
+	setQuery(values, "cursor", opts.Cursor)
+	return values
+}
+
 type submitClaimEnvelope struct {
 	RecordID        string          `json:"record_id"`
 	Status          string          `json:"status"`
@@ -285,11 +340,36 @@ type recordsEnvelope struct {
 }
 
 type rootsEnvelope struct {
-	Roots []BatchRoot `json:"roots"`
+	Roots      []BatchRoot `json:"roots"`
+	Limit      int         `json:"limit"`
+	Direction  string      `json:"direction"`
+	NextCursor string      `json:"next_cursor,omitempty"`
 }
 
 type anchorEnvelope struct {
-	TreeSize uint64           `json:"tree_size"`
-	Status   string           `json:"status"`
-	Result   *STHAnchorResult `json:"result,omitempty"`
+	TreeSize uint64                     `json:"tree_size"`
+	Status   string                     `json:"status"`
+	Result   *STHAnchorResult           `json:"result,omitempty"`
+	Outbox   *model.STHAnchorOutboxItem `json:"outbox,omitempty"`
+}
+
+type sthsEnvelope struct {
+	STHs       []SignedTreeHead `json:"sths"`
+	Limit      int              `json:"limit"`
+	Direction  string           `json:"direction"`
+	NextCursor string           `json:"next_cursor,omitempty"`
+}
+
+type globalLeavesEnvelope struct {
+	Leaves     []model.GlobalLogLeaf `json:"leaves"`
+	Limit      int                   `json:"limit"`
+	Direction  string                `json:"direction"`
+	NextCursor string                `json:"next_cursor,omitempty"`
+}
+
+type anchorsEnvelope struct {
+	Anchors    []anchorEnvelope `json:"anchors"`
+	Limit      int              `json:"limit"`
+	Direction  string           `json:"direction"`
+	NextCursor string           `json:"next_cursor,omitempty"`
 }

--- a/sdk/types.go
+++ b/sdk/types.go
@@ -71,14 +71,56 @@ type ListRecordsOptions struct {
 	BatchID           string
 	TenantID          string
 	ClientID          string
+	ProofLevel        string
 	Query             string
 	ContentHashHex    string
 	ReceivedFromUnixN int64
 	ReceivedToUnixN   int64
 }
 
+type ListPageOptions struct {
+	Limit     int
+	Direction string
+	Cursor    string
+}
+
 type RecordPage struct {
 	Records    []RecordIndex
+	Limit      int
+	Direction  string
+	NextCursor string
+}
+
+type RootPage struct {
+	Roots      []BatchRoot
+	Limit      int
+	Direction  string
+	NextCursor string
+}
+
+type TreeHeadPage struct {
+	STHs       []SignedTreeHead
+	Limit      int
+	Direction  string
+	NextCursor string
+}
+
+type GlobalLeafPage struct {
+	Leaves     []model.GlobalLogLeaf
+	Limit      int
+	Direction  string
+	NextCursor string
+}
+
+type AnchorPageItem struct {
+	TreeSize uint64
+	Status   string
+	Result   *STHAnchorResult
+	Outbox   *model.STHAnchorOutboxItem
+}
+
+type AnchorPage struct {
+	Anchors    []AnchorPageItem
 	Limit      int
 	Direction  string
 	NextCursor string


### PR DESCRIPTION
## Summary
- 补齐服务端 `records / roots / STH / global-log leaves / STH anchors` 的统一 keyset 分页接口，并在 HTTP 与 gRPC 两套入口保持一致的 `limit + cursor + direction` 语义
- 扩展 Go SDK 与桌面客户端，远程记录列表支持 `L4/L5` 过滤与新分页接口，不再依赖本地回退兜底
- 在 proofstore 中补上记录索引的 L4/L5 提升逻辑，并修复 file store 在索引升级期间 `GetRecord` 可能短暂读空的可见性空窗

## Testing
- `go test -p 1 ./...`
- `go test -p 1 -tags=integration ./...`
- `go test -p 1 -tags=e2e ./...`
- `go test -p 1 -race ./...`
- `cd clients/desktop && go test -p 1 ./...`
- `cd clients/desktop && go test -p 1 -race ./...`
- `cd clients/desktop && go vet ./...`
- `cd clients/desktop && npm --prefix frontend run build`
- `cd clients/desktop && wails build`

Closes #15