### PR TITLE
feat: add Admin Merkle visualizations

### DIFF
--- a/clients/web/src/components/HashChip.vue
+++ b/clients/web/src/components/HashChip.vue
@@ -2,10 +2,10 @@
 import { computed } from 'vue'
 import { Copy, Check } from 'lucide-vue-next'
 import { ref } from 'vue'
-import { copyToClipboard, shortHash } from '@/lib/format'
+import { bytesToHex, copyToClipboard, shortHash, type BytesLike } from '@/lib/format'
 
 const props = defineProps<{
-  value?: string
+  value?: BytesLike
   mono?: boolean
   full?: boolean
   label?: string
@@ -14,15 +14,19 @@ const props = defineProps<{
 }>()
 
 const copied = ref(false)
+const normalized = computed(() => {
+  if (typeof props.value === 'string') return props.value
+  return bytesToHex(props.value)
+})
 const display = computed(() => {
-  if (!props.value) return '—'
-  if (props.full) return props.value
-  return shortHash(props.value, props.head ?? 8, props.tail ?? 6)
+  if (!normalized.value) return '—'
+  if (props.full) return normalized.value
+  return shortHash(normalized.value, props.head ?? 8, props.tail ?? 6)
 })
 
 async function copy() {
-  if (!props.value) return
-  await copyToClipboard(props.value)
+  if (!normalized.value) return
+  await copyToClipboard(normalized.value)
   copied.value = true
   setTimeout(() => (copied.value = false), 1200)
 }
@@ -32,7 +36,7 @@ async function copy() {
   <button
     type="button"
     class="group inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 border border-white/10 bg-[#070807]/70 transition hover:border-accent/45 hover:bg-accent/10"
-    :title="value"
+    :title="normalized"
     @click="copy"
   >
     <span v-if="label" class="font-display text-[10px] uppercase tracking-[0.12em] text-ink-400">{{ label }}</span>

--- a/clients/web/src/components/HashNode.vue
+++ b/clients/web/src/components/HashNode.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { bytesToHex, shortHash, type BytesLike } from '@/lib/format'
+
+const props = defineProps<{
+  label: string
+  hash?: BytesLike
+  meta?: string
+  active?: boolean
+}>()
+
+const hex = () => bytesToHex(props.hash)
+</script>
+
+<template>
+  <div
+    class="rounded-[14px] border px-3 py-2 bg-[#080a08]/80 min-w-[180px]"
+    :class="active ? 'border-accent/70 shadow-acid' : 'border-white/10'"
+  >
+    <div class="flex items-center justify-between gap-3">
+      <span class="text-[11px] font-bold text-ink-200">{{ label }}</span>
+      <span v-if="meta" class="text-[10px] text-ink-500">{{ meta }}</span>
+    </div>
+    <div class="mt-1 font-mono text-[11px] text-accent" :title="hex()">
+      {{ shortHash(hex(), 10, 8) || '—' }}
+    </div>
+  </div>
+</template>

--- a/clients/web/src/components/MerkleTreeExplorer.test.ts
+++ b/clients/web/src/components/MerkleTreeExplorer.test.ts
@@ -1,0 +1,24 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import MerkleTreeExplorer from './MerkleTreeExplorer.vue'
+
+describe('MerkleTreeExplorer', () => {
+  it('renders paged nodes and emits loadMore', async () => {
+    const wrapper = mount(MerkleTreeExplorer, {
+      props: {
+        nodes: [{ schema_version: 'x', batch_id: 'b1', level: 1, start_index: 0, width: 2, hash: [1, 2, 3] }],
+        nextCursor: 'cursor',
+      },
+    })
+
+    expect(wrapper.text()).toContain('L1 / start 0')
+    expect(wrapper.text()).toContain('width 2')
+    await wrapper.get('button').trigger('click')
+    expect(wrapper.emitted('loadMore')).toHaveLength(1)
+  })
+
+  it('renders empty state for missing nodes', () => {
+    const wrapper = mount(MerkleTreeExplorer, { props: { nodes: [], emptyLabel: '暂无树节点' } })
+    expect(wrapper.text()).toContain('暂无树节点')
+  })
+})

--- a/clients/web/src/components/MerkleTreeExplorer.test.ts
+++ b/clients/web/src/components/MerkleTreeExplorer.test.ts
@@ -3,11 +3,12 @@ import { describe, expect, it } from 'vitest'
 import MerkleTreeExplorer from './MerkleTreeExplorer.vue'
 
 describe('MerkleTreeExplorer', () => {
-  it('renders paged nodes and emits loadMore', async () => {
+  it('renders canvas nodes and emits loadMore', async () => {
     const wrapper = mount(MerkleTreeExplorer, {
       props: {
         nodes: [{ schema_version: 'x', batch_id: 'b1', level: 1, start_index: 0, width: 2, hash: [1, 2, 3] }],
         nextCursor: 'cursor',
+        treeSize: 2,
       },
     })
 
@@ -20,5 +21,17 @@ describe('MerkleTreeExplorer', () => {
   it('renders empty state for missing nodes', () => {
     const wrapper = mount(MerkleTreeExplorer, { props: { nodes: [], emptyLabel: '暂无树节点' } })
     expect(wrapper.text()).toContain('暂无树节点')
+  })
+
+  it('emits expand when an expandable canvas node is clicked', async () => {
+    const wrapper = mount(MerkleTreeExplorer, {
+      props: {
+        nodes: [{ schema_version: 'x', batch_id: 'b1', level: 1, start_index: 0, width: 2, hash: [1, 2, 3] }],
+        treeSize: 2,
+      },
+    })
+
+    await wrapper.get('canvas').trigger('click', { clientX: 380, clientY: 88 })
+    expect(wrapper.emitted('expand')?.[0]?.[0]).toMatchObject({ level: 1, start_index: 0, width: 2 })
   })
 })

--- a/clients/web/src/components/MerkleTreeExplorer.vue
+++ b/clients/web/src/components/MerkleTreeExplorer.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import HashNode from './HashNode.vue'
+import Button from './Button.vue'
+import type { BatchTreeNode, GlobalLogNode } from '@/lib/api'
+
+defineProps<{
+  nodes: Array<BatchTreeNode | GlobalLogNode>
+  loading?: boolean
+  nextCursor?: string
+  emptyLabel?: string
+}>()
+
+const emit = defineEmits<{ loadMore: [] }>()
+</script>
+
+<template>
+  <div>
+    <div v-if="nodes.length" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+      <HashNode
+        v-for="node in nodes"
+        :key="`${node.level}:${node.start_index}`"
+        :label="`L${node.level} / start ${node.start_index}`"
+        :hash="node.hash"
+        :meta="`width ${node.width}`"
+        :active="node.width > 1"
+      />
+    </div>
+    <p v-else class="text-[12px] text-ink-500">{{ emptyLabel || '暂无节点，调整 level/start 后重试。' }}</p>
+    <div v-if="nextCursor" class="mt-4">
+      <Button size="sm" variant="subtle" :loading="loading" @click="emit('loadMore')">加载更多节点</Button>
+    </div>
+  </div>
+</template>

--- a/clients/web/src/components/MerkleTreeExplorer.vue
+++ b/clients/web/src/components/MerkleTreeExplorer.vue
@@ -1,29 +1,365 @@
 <script setup lang="ts">
-import HashNode from './HashNode.vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import Button from './Button.vue'
 import type { BatchTreeNode, GlobalLogNode } from '@/lib/api'
+import { bytesToHex, shortHash } from '@/lib/format'
 
-defineProps<{
-  nodes: Array<BatchTreeNode | GlobalLogNode>
+type TreeNode = BatchTreeNode | GlobalLogNode
+
+type HitNode = {
+  key: string
+  node: TreeNode
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+const props = defineProps<{
+  nodes: TreeNode[]
   loading?: boolean
   nextCursor?: string
   emptyLabel?: string
+  treeSize?: number
 }>()
 
-const emit = defineEmits<{ loadMore: [] }>()
+const emit = defineEmits<{
+  loadMore: []
+  expand: [node: TreeNode]
+}>()
+
+const canvas = ref<HTMLCanvasElement | null>(null)
+const frame = ref<HTMLDivElement | null>(null)
+const viewportWidth = ref(760)
+const selectedKey = ref('')
+const hoveredKey = ref('')
+const hits = ref<HitNode[]>([])
+let resizeObserver: ResizeObserver | undefined
+
+const sortedNodes = computed(() => {
+  return [...props.nodes].sort((a, b) => {
+    if (a.level !== b.level) return b.level - a.level
+    return a.start_index - b.start_index
+  })
+})
+
+const selectedNode = computed(() => {
+  const hit = hits.value.find((item) => item.key === selectedKey.value)
+  return hit?.node ?? sortedNodes.value[0]
+})
+
+const canvasHeight = computed(() => {
+  if (!sortedNodes.value.length) return 320
+  const levelCount = new Set(sortedNodes.value.map((node) => node.level)).size
+  return Math.max(360, Math.min(860, 130 + levelCount * 112))
+})
+
+const canvasWidth = computed(() => {
+  const nodeWidth = nodeBoxWidth()
+  const rowCounts = new Map<number, number>()
+  for (const node of sortedNodes.value) {
+    rowCounts.set(node.level, (rowCounts.get(node.level) ?? 0) + 1)
+  }
+  const maxRowCount = Math.max(1, ...rowCounts.values())
+  return Math.max(viewportWidth.value, 96 + maxRowCount * nodeWidth + (maxRowCount - 1) * 56)
+})
+
+function keyOf(node: TreeNode): string {
+  return `${node.level}:${node.start_index}:${node.width}`
+}
+
+function shortNodeHash(node: TreeNode): string {
+  return shortHash(bytesToHex(node.hash), 8, 8) || '—'
+}
+
+function nodeRangeLabel(node: TreeNode): string {
+  return `L${node.level} / start ${node.start_index} / width ${node.width}`
+}
+
+function childRanges(node: TreeNode): Array<{ level: number; start: number; width: number }> {
+  if (node.width <= 1) return []
+  const leftWidth = largestPowerOfTwoLessThan(node.width)
+  const rightWidth = node.width - leftWidth
+  return [
+    { level: rangeLevel(leftWidth), start: node.start_index, width: leftWidth },
+    { level: rangeLevel(rightWidth), start: node.start_index + leftWidth, width: rightWidth },
+  ]
+}
+
+function childKey(range: { level: number; start: number; width: number }): string {
+  return `${range.level}:${range.start}:${range.width}`
+}
+
+function rangeLevel(size: number): number {
+  if (size <= 1) return 0
+  let level = 0
+  let width = 1
+  while (width < size) {
+    width <<= 1
+    level += 1
+  }
+  return level
+}
+
+function largestPowerOfTwoLessThan(size: number): number {
+  let out = 1
+  while (out << 1 < size) out <<= 1
+  return out
+}
+
+function roundedRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number) {
+  const radius = Math.min(r, w / 2, h / 2)
+  ctx.beginPath()
+  ctx.moveTo(x + radius, y)
+  ctx.arcTo(x + w, y, x + w, y + h, radius)
+  ctx.arcTo(x + w, y + h, x, y + h, radius)
+  ctx.arcTo(x, y + h, x, y, radius)
+  ctx.arcTo(x, y, x + w, y, radius)
+  ctx.closePath()
+}
+
+function nodeBoxWidth(): number {
+  return viewportWidth.value < 680 ? 150 : 178
+}
+
+function setCanvasSize() {
+  const nextWidth = frame.value?.clientWidth || 760
+  viewportWidth.value = Math.max(360, nextWidth)
+  draw()
+}
+
+function layoutNodes(): HitNode[] {
+  const nodes = sortedNodes.value
+  if (!nodes.length) return []
+
+  const paddingX = 48
+  const paddingY = 54
+  const nodeWidth = nodeBoxWidth()
+  const nodeHeight = 68
+  const gap = 56
+  const drawWidth = canvasWidth.value
+  const drawableWidth = Math.max(1, drawWidth - paddingX * 2)
+  const maxLevel = Math.max(...nodes.map((node) => node.level))
+  const totalWidth = Math.max(
+    props.treeSize || 0,
+    ...nodes.map((node) => node.start_index + Math.max(1, node.width)),
+  )
+  const levels = [...new Set(nodes.map((node) => node.level))].sort((a, b) => b - a)
+  const levelIndex = new Map(levels.map((level, index) => [level, index]))
+  const byLevel = new Map<number, HitNode[]>()
+
+  for (const node of nodes) {
+    const center = node.start_index + Math.max(1, node.width) / 2
+    const x = paddingX + (center / totalWidth) * drawableWidth - nodeWidth / 2
+    const row = levelIndex.get(node.level) ?? Math.max(0, maxLevel - node.level)
+    const hit = {
+      key: keyOf(node),
+      node,
+      x,
+      y: paddingY + row * 108,
+      width: nodeWidth,
+      height: nodeHeight,
+    }
+    const rowHits = byLevel.get(node.level) ?? []
+    rowHits.push(hit)
+    byLevel.set(node.level, rowHits)
+  }
+
+  const out: HitNode[] = []
+  for (const rowHits of byLevel.values()) {
+    rowHits.sort((a, b) => a.node.start_index - b.node.start_index)
+    for (let i = 0; i < rowHits.length; i += 1) {
+      const previous = rowHits[i - 1]
+      rowHits[i].x = Math.max(12, rowHits[i].x)
+      if (previous) rowHits[i].x = Math.max(rowHits[i].x, previous.x + previous.width + gap)
+    }
+    const overflow = rowHits.length ? rowHits[rowHits.length - 1].x + nodeWidth + 12 - drawWidth : 0
+    if (overflow > 0) {
+      for (const hit of rowHits) hit.x -= overflow
+    }
+    if (rowHits.length && rowHits[0].x < 12) {
+      const shift = 12 - rowHits[0].x
+      for (const hit of rowHits) hit.x += shift
+    }
+    out.push(...rowHits)
+  }
+  return out
+}
+
+function draw() {
+  const el = canvas.value
+  if (!el) return
+  const ctx = el.getContext('2d')
+  if (!ctx) return
+
+  const dpr = window.devicePixelRatio || 1
+  const height = canvasHeight.value
+  const drawWidth = canvasWidth.value
+  el.width = Math.floor(drawWidth * dpr)
+  el.height = Math.floor(height * dpr)
+  el.style.width = `${drawWidth}px`
+  el.style.height = `${height}px`
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+  ctx.clearRect(0, 0, drawWidth, height)
+
+  const gradient = ctx.createLinearGradient(0, 0, drawWidth, height)
+  gradient.addColorStop(0, '#111a12')
+  gradient.addColorStop(0.55, '#070907')
+  gradient.addColorStop(1, '#0b1110')
+  ctx.fillStyle = gradient
+  ctx.fillRect(0, 0, drawWidth, height)
+
+  ctx.strokeStyle = 'rgba(188, 255, 86, 0.07)'
+  ctx.lineWidth = 1
+  for (let x = 24; x < drawWidth; x += 42) {
+    ctx.beginPath()
+    ctx.moveTo(x, 0)
+    ctx.lineTo(x, height)
+    ctx.stroke()
+  }
+  for (let y = 28; y < height; y += 42) {
+    ctx.beginPath()
+    ctx.moveTo(0, y)
+    ctx.lineTo(drawWidth, y)
+    ctx.stroke()
+  }
+
+  const nextHits = layoutNodes()
+  hits.value = nextHits
+  const byKey = new Map(nextHits.map((hit) => [hit.key, hit]))
+
+  ctx.lineCap = 'round'
+  for (const hit of nextHits) {
+    for (const range of childRanges(hit.node)) {
+      const child = byKey.get(childKey(range))
+      if (!child) continue
+      const startX = hit.x + hit.width / 2
+      const startY = hit.y + hit.height
+      const endX = child.x + child.width / 2
+      const endY = child.y
+      const edge = ctx.createLinearGradient(startX, startY, endX, endY)
+      edge.addColorStop(0, 'rgba(188, 255, 86, 0.55)')
+      edge.addColorStop(1, 'rgba(77, 163, 255, 0.28)')
+      ctx.strokeStyle = edge
+      ctx.lineWidth = 2
+      ctx.beginPath()
+      ctx.moveTo(startX, startY)
+      const midY = (startY + endY) / 2
+      ctx.bezierCurveTo(startX, midY, endX, midY, endX, endY)
+      ctx.stroke()
+    }
+  }
+
+  for (const hit of nextHits) {
+    const isSelected = hit.key === selectedKey.value
+    const isHovered = hit.key === hoveredKey.value
+    const expandable = hit.node.width > 1
+    const fill = isSelected ? 'rgba(188, 255, 86, 0.16)' : expandable ? 'rgba(11, 18, 12, 0.92)' : 'rgba(8, 10, 9, 0.88)'
+    const border = isSelected ? 'rgba(188, 255, 86, 0.95)' : isHovered ? 'rgba(188, 255, 86, 0.65)' : 'rgba(255, 255, 255, 0.16)'
+
+    ctx.shadowColor = isSelected ? 'rgba(188, 255, 86, 0.28)' : 'rgba(0, 0, 0, 0.22)'
+    ctx.shadowBlur = isSelected ? 18 : 10
+    roundedRect(ctx, hit.x, hit.y, hit.width, hit.height, 16)
+    ctx.fillStyle = fill
+    ctx.fill()
+    ctx.shadowBlur = 0
+    ctx.strokeStyle = border
+    ctx.lineWidth = isSelected ? 2 : 1
+    ctx.stroke()
+
+    ctx.fillStyle = expandable ? '#bcff56' : '#7dd3fc'
+    ctx.beginPath()
+    ctx.arc(hit.x + 18, hit.y + 18, 5, 0, Math.PI * 2)
+    ctx.fill()
+
+    ctx.font = '700 11px ui-monospace, SFMono-Regular, Menlo, monospace'
+    ctx.fillStyle = '#f6fff0'
+    ctx.fillText(`L${hit.node.level} / start ${hit.node.start_index}`, hit.x + 32, hit.y + 22)
+
+    ctx.font = '10px ui-monospace, SFMono-Regular, Menlo, monospace'
+    ctx.fillStyle = '#92a08e'
+    ctx.fillText(`width ${hit.node.width}${expandable ? ' · click to expand' : ' · leaf'}`, hit.x + 14, hit.y + 42)
+
+    ctx.font = '11px ui-monospace, SFMono-Regular, Menlo, monospace'
+    ctx.fillStyle = '#bcff56'
+    ctx.fillText(shortNodeHash(hit.node), hit.x + 14, hit.y + 60)
+  }
+}
+
+function eventPoint(event: MouseEvent): { x: number; y: number } {
+  const rect = canvas.value?.getBoundingClientRect()
+  if (!rect) return { x: 0, y: 0 }
+  return {
+    x: event.clientX - rect.left,
+    y: event.clientY - rect.top,
+  }
+}
+
+function hitAt(event: MouseEvent): HitNode | undefined {
+  const point = eventPoint(event)
+  for (let i = hits.value.length - 1; i >= 0; i -= 1) {
+    const hit = hits.value[i]
+    if (point.x >= hit.x && point.x <= hit.x + hit.width && point.y >= hit.y && point.y <= hit.y + hit.height) return hit
+  }
+  return undefined
+}
+
+function handleMove(event: MouseEvent) {
+  const hit = hitAt(event)
+  hoveredKey.value = hit?.key ?? ''
+  if (canvas.value) canvas.value.style.cursor = hit ? 'pointer' : 'default'
+}
+
+function handleLeave() {
+  hoveredKey.value = ''
+  if (canvas.value) canvas.value.style.cursor = 'default'
+}
+
+function handleClick(event: MouseEvent) {
+  const hit = hitAt(event)
+  if (!hit) return
+  selectedKey.value = hit.key
+  if (hit.node.width > 1) emit('expand', hit.node)
+}
+
+watch([sortedNodes, viewportWidth, canvasHeight, canvasWidth, selectedKey, hoveredKey], () => nextTick(draw), { deep: true })
+
+onMounted(() => {
+  if (typeof ResizeObserver !== 'undefined') {
+    resizeObserver = new ResizeObserver(setCanvasSize)
+    if (frame.value) resizeObserver.observe(frame.value)
+  }
+  setCanvasSize()
+})
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect()
+})
 </script>
 
 <template>
   <div>
-    <div v-if="nodes.length" class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
-      <HashNode
-        v-for="node in nodes"
-        :key="`${node.level}:${node.start_index}`"
-        :label="`L${node.level} / start ${node.start_index}`"
-        :hash="node.hash"
-        :meta="`width ${node.width}`"
-        :active="node.width > 1"
+    <div v-if="nodes.length" ref="frame" class="overflow-x-auto overflow-y-hidden rounded-[18px] border border-white/10 bg-[#050605]">
+      <canvas
+        ref="canvas"
+        class="block"
+        role="img"
+        aria-label="Merkle tree canvas explorer"
+        @mousemove="handleMove"
+        @mouseleave="handleLeave"
+        @click="handleClick"
       />
+      <div class="flex flex-wrap items-center justify-between gap-3 border-t border-white/10 px-4 py-3 text-[11px] text-ink-400">
+        <div>
+          <span class="text-ink-200">当前节点：</span>
+          <span v-if="selectedNode" class="font-mono text-accent">{{ nodeRangeLabel(selectedNode) }}</span>
+          <span v-else>暂无</span>
+        </div>
+        <div class="flex gap-3">
+          <span>可见 {{ nodes.length }} 个节点</span>
+          <span>点击非叶子节点按需展开</span>
+        </div>
+      </div>
     </div>
     <p v-else class="text-[12px] text-ink-500">{{ emptyLabel || '暂无节点，调整 level/start 后重试。' }}</p>
     <div v-if="nextCursor" class="mt-4">

--- a/clients/web/src/components/ProofPathGraph.test.ts
+++ b/clients/web/src/components/ProofPathGraph.test.ts
@@ -1,0 +1,36 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import ProofPathGraph from './ProofPathGraph.vue'
+
+describe('ProofPathGraph', () => {
+  it('renders leaf, siblings and batch root', () => {
+    const wrapper = mount(ProofPathGraph, {
+      props: {
+        proof: {
+          record_id: 'rec-a',
+          proof_level: 'L5',
+          proof_bundle: {
+            record_id: 'rec-a',
+            committed_receipt: {
+              batch_id: 'batch-a',
+              leaf_index: 0,
+              leaf_hash: [1],
+              batch_root: [9],
+              batch_closed_at_unix_nano: 100,
+            },
+            batch_proof: {
+              tree_alg: 'rfc6962-sha256',
+              leaf_index: 0,
+              tree_size: 2,
+              audit_path: [[2]],
+            },
+          },
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('Leaf')
+    expect(wrapper.text()).toContain('Sibling 1')
+    expect(wrapper.text()).toContain('Batch Root')
+  })
+})

--- a/clients/web/src/components/ProofPathGraph.vue
+++ b/clients/web/src/components/ProofPathGraph.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import HashNode from './HashNode.vue'
+import type { ProofResponse } from '@/lib/api'
+
+defineProps<{ proof: ProofResponse | null }>()
+</script>
+
+<template>
+  <div v-if="proof" class="overflow-x-auto">
+    <div class="flex items-center gap-3 min-w-max py-2">
+      <HashNode
+        label="Leaf"
+        :hash="proof.proof_bundle.committed_receipt.leaf_hash"
+        :meta="`#${proof.proof_bundle.committed_receipt.leaf_index}`"
+        active
+      />
+      <template v-for="(hash, i) in proof.proof_bundle.batch_proof.audit_path" :key="i">
+        <span class="text-ink-600">→</span>
+        <HashNode :label="`Sibling ${i + 1}`" :hash="hash" :meta="`path[${i}]`" />
+      </template>
+      <span class="text-ink-600">→</span>
+      <HashNode label="Batch Root" :hash="proof.proof_bundle.committed_receipt.batch_root" :meta="`size ${proof.proof_bundle.batch_proof.tree_size}`" active />
+    </div>
+  </div>
+  <p v-else class="text-[12px] text-ink-500">输入 record_id 后查看从 leaf 到 batch root 的 proof path。</p>
+</template>

--- a/clients/web/src/components/Sidebar.vue
+++ b/clients/web/src/components/Sidebar.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { RouterLink, useRoute, useRouter } from 'vue-router'
-import { LayoutDashboard, Activity, ScrollText, Settings as SettingsIcon, LogOut } from 'lucide-vue-next'
+import { LayoutDashboard, Activity, ScrollText, Settings as SettingsIcon, LogOut, GitBranch, Network } from 'lucide-vue-next'
 import { computed } from 'vue'
 import TrustDBLogo from './TrustDBLogo.vue'
 import { useAuth } from '@/stores/auth'
@@ -16,6 +16,8 @@ const navGroups = [
       { to: '/dashboard', label: '概览', icon: LayoutDashboard },
       { to: '/metrics', label: '指标', icon: Activity },
       { to: '/records', label: '记录', icon: ScrollText },
+      { to: '/batches', label: '批次', icon: GitBranch },
+      { to: '/global-tree', label: '全局树', icon: Network },
       { to: '/settings', label: '系统设置', icon: SettingsIcon },
     ],
   },
@@ -24,7 +26,7 @@ const navGroups = [
 const activePath = computed(() => route.path)
 
 function isActive(to: string): boolean {
-  return activePath.value === to || (to === '/dashboard' && activePath.value === '/')
+  return activePath.value === to || (to === '/dashboard' && activePath.value === '/') || (to === '/batches' && activePath.value.startsWith('/batches/'))
 }
 
 async function doLogout() {

--- a/clients/web/src/lib/api.test.ts
+++ b/clients/web/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { getBatchDetail, getBatches, getBatchTreeNodes, getGlobalTree, getMetrics, login, proxyGet, putConfigYaml } from './api'
+import { getBatchDetail, getBatches, getBatchTreeNodes, getGlobalTree, getGlobalTreeNodes, getMetrics, login, proxyGet, putConfigYaml } from './api'
 
 const fetchMock = vi.fn()
 
@@ -75,9 +75,13 @@ describe('admin API facade', () => {
   })
 
   it('loads global tree through the proxy facade', async () => {
-    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, state: { tree_size: 2 } }), { status: 200 }))
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, state: { tree_size: 2 } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ nodes: [{ level: 0, start_index: 1 }] }), { status: 200 }))
 
     await expect(getGlobalTree()).resolves.toMatchObject({ ok: true, state: { tree_size: 2 } })
-    expect(fetchMock).toHaveBeenCalledWith('/admin/api/proxy/v1/global-log/tree', { credentials: 'include' })
+    await expect(getGlobalTreeNodes({ level: 0, start: 1, limit: 1 })).resolves.toMatchObject({ nodes: [{ start_index: 1 }] })
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/admin/api/proxy/v1/global-log/tree', { credentials: 'include' })
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/admin/api/proxy/v1/global-log/tree/nodes?level=0&start=1&limit=1', { credentials: 'include' })
   })
 })

--- a/clients/web/src/lib/api.test.ts
+++ b/clients/web/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { getMetrics, login, proxyGet, putConfigYaml } from './api'
+import { getBatchDetail, getBatches, getBatchTreeNodes, getGlobalTree, getMetrics, login, proxyGet, putConfigYaml } from './api'
 
 const fetchMock = vi.fn()
 
@@ -57,5 +57,27 @@ describe('admin API facade', () => {
     await proxyGet('/v1/records?limit=5')
 
     expect(fetchMock).toHaveBeenCalledWith('/admin/api/proxy/v1/records?limit=5', { credentials: 'include' })
+  })
+
+  it('loads batch and tree endpoints through the proxy facade', async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({ roots: [{ batch_id: 'batch-a' }], next_cursor: 'c1' }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ root: { batch_id: 'batch-a' }, manifest: { batch_id: 'batch-a' }, record_count: 2 }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ nodes: [{ level: 0, start_index: 0, width: 1 }] }), { status: 200 }))
+
+    await expect(getBatches({ limit: 10 })).resolves.toMatchObject({ next_cursor: 'c1' })
+    await expect(getBatchDetail('batch-a')).resolves.toMatchObject({ record_count: 2 })
+    await expect(getBatchTreeNodes('batch-a', { level: 0, start: 0 })).resolves.toMatchObject({ nodes: [{ level: 0 }] })
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/admin/api/proxy/v1/batches?limit=10', { credentials: 'include' })
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/admin/api/proxy/v1/batches/batch-a', { credentials: 'include' })
+    expect(fetchMock).toHaveBeenNthCalledWith(3, '/admin/api/proxy/v1/batches/batch-a/tree/nodes?level=0&start=0', { credentials: 'include' })
+  })
+
+  it('loads global tree through the proxy facade', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, state: { tree_size: 2 } }), { status: 200 }))
+
+    await expect(getGlobalTree()).resolves.toMatchObject({ ok: true, state: { tree_size: 2 } })
+    expect(fetchMock).toHaveBeenCalledWith('/admin/api/proxy/v1/global-log/tree', { credentials: 'include' })
   })
 })

--- a/clients/web/src/lib/api.ts
+++ b/clients/web/src/lib/api.ts
@@ -241,8 +241,8 @@ export async function getGlobalTree(): Promise<{ ok: boolean; state?: GlobalLogS
   return proxyJSON('/v1/global-log/tree')
 }
 
-export async function getGlobalTreeNodes(opts: { level?: number; limit?: number; cursor?: string } = {}): Promise<{ nodes: GlobalLogNode[]; next_cursor?: string }> {
-  return proxyJSON(withParams('/v1/global-log/tree/nodes', { level: opts.level, limit: opts.limit, cursor: opts.cursor }))
+export async function getGlobalTreeNodes(opts: { level?: number; start?: number; limit?: number; cursor?: string } = {}): Promise<{ nodes: GlobalLogNode[]; next_cursor?: string }> {
+  return proxyJSON(withParams('/v1/global-log/tree/nodes', { level: opts.level, start: opts.start, limit: opts.limit, cursor: opts.cursor }))
 }
 
 export async function getGlobalLeaves(opts: { limit?: number; cursor?: string } = {}): Promise<{ leaves: GlobalLogLeaf[]; next_cursor?: string }> {

--- a/clients/web/src/lib/api.ts
+++ b/clients/web/src/lib/api.ts
@@ -8,6 +8,110 @@ export type Metric = {
   value: number
 }
 
+export type BatchRoot = {
+  schema_version: string
+  batch_id: string
+  node_id?: string
+  log_id?: string
+  batch_root: string | number[]
+  tree_size: number
+  closed_at_unix_nano: number
+}
+
+export type BatchManifest = {
+  schema_version: string
+  batch_id: string
+  node_id?: string
+  log_id?: string
+  state: string
+  tree_alg: string
+  tree_size: number
+  batch_root: string | number[]
+  record_ids: string[]
+  closed_at_unix_nano: number
+  prepared_at_unix_nano?: number
+  committed_at_unix_nano?: number
+  wal_range?: unknown
+}
+
+export type BatchTreeLeaf = {
+  schema_version: string
+  batch_id: string
+  record_id: string
+  leaf_index: number
+  leaf_hash: string | number[]
+  created_at_unix_nano?: number
+}
+
+export type BatchTreeNode = {
+  schema_version: string
+  batch_id: string
+  level: number
+  start_index: number
+  width: number
+  hash: string | number[]
+  created_at_unix_nano?: number
+}
+
+export type SignedTreeHead = {
+  schema_version: string
+  tree_alg: string
+  tree_size: number
+  root_hash: string | number[]
+  timestamp_unix_nano: number
+  node_id?: string
+  log_id?: string
+}
+
+export type GlobalLogState = {
+  schema_version: string
+  tree_size: number
+  root_hash?: string | number[]
+  frontier: Array<string | number[]>
+  updated_at_unix_nano: number
+}
+
+export type GlobalLogLeaf = {
+  schema_version: string
+  batch_id: string
+  batch_root: string | number[]
+  batch_tree_size: number
+  batch_closed_at_unix_nano: number
+  leaf_index: number
+  leaf_hash: string | number[]
+  appended_at_unix_nano: number
+}
+
+export type GlobalLogNode = {
+  schema_version: string
+  level: number
+  start_index: number
+  width: number
+  hash: string | number[]
+  created_at_unix_nano: number
+}
+
+export type ProofResponse = {
+  record_id: string
+  proof_level: string
+  proof_bundle: {
+    record_id: string
+    committed_receipt: {
+      batch_id: string
+      leaf_index: number
+      leaf_hash: string | number[]
+      batch_root: string | number[]
+      batch_closed_at_unix_nano: number
+    }
+    batch_proof: {
+      tree_alg: string
+      leaf_index: number
+      tree_size: number
+      audit_path: Array<string | number[]>
+    }
+  }
+}
+
 async function parseJSON<T>(res: Response): Promise<T> {
   const text = await res.text()
   try {
@@ -95,4 +199,52 @@ export async function putConfigYaml(yaml: string): Promise<{ backup?: string }> 
 export async function proxyGet(path: string): Promise<Response> {
   const p = path.startsWith('/') ? path : `/${path}`
   return fetch(adminApiPrefix + '/proxy' + p, { credentials: 'include' })
+}
+
+async function proxyJSON<T>(path: string): Promise<T> {
+  const res = await proxyGet(path)
+  const j = await parseJSON<T & { code?: string; message?: string }>(res)
+  if (!res.ok) throw new Error(j.message || res.statusText)
+  return j
+}
+
+function withParams(path: string, params: Record<string, string | number | undefined>): string {
+  const qs = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== '') qs.set(key, String(value))
+  }
+  const query = qs.toString()
+  return query ? `${path}?${query}` : path
+}
+
+export async function getBatches(opts: { limit?: number; cursor?: string } = {}): Promise<{ roots: BatchRoot[]; next_cursor?: string }> {
+  return proxyJSON(withParams('/v1/batches', { limit: opts.limit, cursor: opts.cursor }))
+}
+
+export async function getBatchDetail(batchID: string): Promise<{ root: BatchRoot; manifest: BatchManifest; record_count: number }> {
+  return proxyJSON(`/v1/batches/${encodeURIComponent(batchID)}`)
+}
+
+export async function getBatchLeaves(batchID: string, opts: { limit?: number; cursor?: string } = {}): Promise<{ leaves: BatchTreeLeaf[]; next_cursor?: string }> {
+  return proxyJSON(withParams(`/v1/batches/${encodeURIComponent(batchID)}/tree/leaves`, { limit: opts.limit, cursor: opts.cursor }))
+}
+
+export async function getBatchTreeNodes(batchID: string, opts: { level?: number; start?: number; limit?: number; cursor?: string } = {}): Promise<{ nodes: BatchTreeNode[]; next_cursor?: string }> {
+  return proxyJSON(withParams(`/v1/batches/${encodeURIComponent(batchID)}/tree/nodes`, { level: opts.level, start: opts.start, limit: opts.limit, cursor: opts.cursor }))
+}
+
+export async function getProofPath(recordID: string): Promise<ProofResponse> {
+  return proxyJSON(`/v1/proofs/${encodeURIComponent(recordID)}`)
+}
+
+export async function getGlobalTree(): Promise<{ ok: boolean; state?: GlobalLogState; sth?: SignedTreeHead }> {
+  return proxyJSON('/v1/global-log/tree')
+}
+
+export async function getGlobalTreeNodes(opts: { level?: number; limit?: number; cursor?: string } = {}): Promise<{ nodes: GlobalLogNode[]; next_cursor?: string }> {
+  return proxyJSON(withParams('/v1/global-log/tree/nodes', { level: opts.level, limit: opts.limit, cursor: opts.cursor }))
+}
+
+export async function getGlobalLeaves(opts: { limit?: number; cursor?: string } = {}): Promise<{ leaves: GlobalLogLeaf[]; next_cursor?: string }> {
+  return proxyJSON(withParams('/v1/global-log/tree/leaves', { limit: opts.limit, cursor: opts.cursor }))
 }

--- a/clients/web/src/pages/BatchDetail.vue
+++ b/clients/web/src/pages/BatchDetail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import Card from '@/components/Card.vue'
 import Button from '@/components/Button.vue'
@@ -9,6 +9,8 @@ import ProofPathGraph from '@/components/ProofPathGraph.vue'
 import { getBatchDetail, getBatchLeaves, getBatchTreeNodes, getProofPath, type BatchTreeLeaf, type BatchTreeNode, type ProofResponse } from '@/lib/api'
 import { formatTime, nanoToDate } from '@/lib/format'
 import { RefreshCcw } from 'lucide-vue-next'
+
+type ExpandableNode = Pick<BatchTreeNode, 'level' | 'start_index' | 'width'>
 
 const route = useRoute()
 const batchID = String(route.params.batchID || '')
@@ -23,6 +25,31 @@ const recordID = ref('')
 const proof = ref<ProofResponse | null>(null)
 const loading = ref(false)
 const err = ref('')
+
+const rootLevel = computed(() => rangeLevel(detail.value?.record_count ?? detail.value?.root.tree_size ?? 0))
+
+function rangeLevel(size: number): number {
+  if (size <= 1) return 0
+  let level = 0
+  let width = 1
+  while (width < size) {
+    width <<= 1
+    level += 1
+  }
+  return level
+}
+
+function largestPowerOfTwoLessThan(size: number): number {
+  let out = 1
+  while (out << 1 < size) out <<= 1
+  return out
+}
+
+function mergeNodes(incoming: BatchTreeNode[]) {
+  const map = new Map(nodes.value.map((node) => [`${node.level}:${node.start_index}:${node.width}`, node]))
+  for (const node of incoming) map.set(`${node.level}:${node.start_index}:${node.width}`, node)
+  nodes.value = [...map.values()]
+}
 
 async function loadSummary() {
   detail.value = await getBatchDetail(batchID)
@@ -43,6 +70,34 @@ async function loadNodes(reset: boolean) {
   nodeCursor.value = body.next_cursor ?? ''
 }
 
+async function loadRootNode() {
+  if (!detail.value) return
+  level.value = rootLevel.value
+  start.value = 0
+  const body = await getBatchTreeNodes(batchID, { level: rootLevel.value, start: 0, limit: 1 })
+  nodes.value = body.nodes
+  nodeCursor.value = body.next_cursor ?? ''
+}
+
+async function expandNode(node: ExpandableNode) {
+  if (node.width <= 1) return
+  loading.value = true
+  err.value = ''
+  try {
+    const leftWidth = largestPowerOfTwoLessThan(node.width)
+    const rightWidth = node.width - leftWidth
+    const [left, right] = await Promise.all([
+      getBatchTreeNodes(batchID, { level: rangeLevel(leftWidth), start: node.start_index, limit: 1 }),
+      getBatchTreeNodes(batchID, { level: rangeLevel(rightWidth), start: node.start_index + leftWidth, limit: 1 }),
+    ])
+    mergeNodes(left.nodes.concat(right.nodes))
+  } catch (e: unknown) {
+    err.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
 async function loadProof() {
   if (!recordID.value.trim()) return
   const body = await getProofPath(recordID.value.trim())
@@ -58,7 +113,7 @@ async function refreshAll() {
   try {
     await loadSummary()
     await loadLeaves(true)
-    await loadNodes(true)
+    await loadRootNode()
   } catch (e: unknown) {
     err.value = e instanceof Error ? e.message : String(e)
   } finally {
@@ -145,7 +200,14 @@ onMounted(refreshAll)
             <input v-model.number="start" type="number" min="0" class="h-9 w-[130px] px-3 rounded-[12px] border border-white/10 bg-[#0b0d0b]/80 text-[12px] text-ink-100" placeholder="start" />
             <Button size="sm" variant="subtle" :loading="loading" @click="loadNodes(true)">读取节点</Button>
           </div>
-          <MerkleTreeExplorer :nodes="nodes" :next-cursor="nodeCursor" :loading="loading" @load-more="loadNodes(false)" />
+          <MerkleTreeExplorer
+            :nodes="nodes"
+            :tree-size="detail?.record_count || detail?.root.tree_size"
+            :next-cursor="nodeCursor"
+            :loading="loading"
+            @load-more="loadNodes(false)"
+            @expand="expandNode"
+          />
         </Card>
       </div>
     </div>

--- a/clients/web/src/pages/BatchDetail.vue
+++ b/clients/web/src/pages/BatchDetail.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import Card from '@/components/Card.vue'
+import Button from '@/components/Button.vue'
+import HashChip from '@/components/HashChip.vue'
+import MerkleTreeExplorer from '@/components/MerkleTreeExplorer.vue'
+import ProofPathGraph from '@/components/ProofPathGraph.vue'
+import { getBatchDetail, getBatchLeaves, getBatchTreeNodes, getProofPath, type BatchTreeLeaf, type BatchTreeNode, type ProofResponse } from '@/lib/api'
+import { formatTime, nanoToDate } from '@/lib/format'
+import { RefreshCcw } from 'lucide-vue-next'
+
+const route = useRoute()
+const batchID = String(route.params.batchID || '')
+const detail = ref<Awaited<ReturnType<typeof getBatchDetail>> | null>(null)
+const leaves = ref<BatchTreeLeaf[]>([])
+const nodes = ref<BatchTreeNode[]>([])
+const nodeCursor = ref('')
+const leafCursor = ref('')
+const level = ref(0)
+const start = ref(0)
+const recordID = ref('')
+const proof = ref<ProofResponse | null>(null)
+const loading = ref(false)
+const err = ref('')
+
+async function loadSummary() {
+  detail.value = await getBatchDetail(batchID)
+}
+
+async function loadLeaves(reset: boolean) {
+  if (reset) leafCursor.value = ''
+  const body = await getBatchLeaves(batchID, { limit: 25, cursor: leafCursor.value })
+  leaves.value = reset ? body.leaves : leaves.value.concat(body.leaves)
+  leafCursor.value = body.next_cursor ?? ''
+  if (!recordID.value && leaves.value[0]) recordID.value = leaves.value[0].record_id
+}
+
+async function loadNodes(reset: boolean) {
+  if (reset) nodeCursor.value = ''
+  const body = await getBatchTreeNodes(batchID, { level: level.value, start: start.value, limit: 30, cursor: nodeCursor.value })
+  nodes.value = reset ? body.nodes : nodes.value.concat(body.nodes)
+  nodeCursor.value = body.next_cursor ?? ''
+}
+
+async function loadProof() {
+  if (!recordID.value.trim()) return
+  const body = await getProofPath(recordID.value.trim())
+  if (body.proof_bundle.committed_receipt.batch_id !== batchID) {
+    throw new Error('该 record_id 不属于当前批次')
+  }
+  proof.value = body
+}
+
+async function refreshAll() {
+  loading.value = true
+  err.value = ''
+  try {
+    await loadSummary()
+    await loadLeaves(true)
+    await loadNodes(true)
+  } catch (e: unknown) {
+    err.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function submitProof() {
+  loading.value = true
+  err.value = ''
+  try {
+    await loadProof()
+  } catch (e: unknown) {
+    err.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(refreshAll)
+</script>
+
+<template>
+  <div class="flex flex-col gap-4 max-w-[1280px] mx-auto">
+    <Card title="批次详情" :subtitle="batchID">
+      <template #actions>
+        <Button size="sm" variant="subtle" :loading="loading" @click="refreshAll">
+          <RefreshCcw :size="12" /> 刷新
+        </Button>
+      </template>
+      <p v-if="err" class="mb-3 text-[12px] text-danger">{{ err }}</p>
+      <div v-if="detail" class="grid grid-cols-1 lg:grid-cols-4 gap-3 text-[12px]">
+        <div class="rounded-[14px] bg-white/[0.03] border border-white/10 p-3">
+          <div class="kicker text-[9px]">records</div>
+          <div class="mt-1 font-mono text-accent">{{ detail.record_count }}</div>
+        </div>
+        <div class="rounded-[14px] bg-white/[0.03] border border-white/10 p-3">
+          <div class="kicker text-[9px]">tree size</div>
+          <div class="mt-1 font-mono text-ink-100">{{ detail.root.tree_size }}</div>
+        </div>
+        <div class="rounded-[14px] bg-white/[0.03] border border-white/10 p-3">
+          <div class="kicker text-[9px]">closed</div>
+          <div class="mt-1 text-ink-300">{{ formatTime(nanoToDate(detail.root.closed_at_unix_nano)) }}</div>
+        </div>
+        <div class="rounded-[14px] bg-white/[0.03] border border-white/10 p-3">
+          <div class="kicker text-[9px]">root</div>
+          <div class="mt-1"><HashChip :value="detail.root.batch_root" /></div>
+        </div>
+      </div>
+    </Card>
+
+    <div class="grid grid-cols-1 xl:grid-cols-[360px_minmax(0,1fr)] gap-4">
+      <Card title="批次叶子" subtitle="按需分页，不展开全部记录">
+        <div class="space-y-2 max-h-[560px] overflow-y-auto pr-1">
+          <button
+            v-for="leaf in leaves"
+            :key="leaf.leaf_index"
+            type="button"
+            class="w-full text-left rounded-[12px] border border-white/10 bg-[#070807]/80 p-3 hover:border-accent/50 transition"
+            @click="recordID = leaf.record_id"
+          >
+            <div class="flex justify-between gap-2 text-[11px] text-ink-400">
+              <span>#{{ leaf.leaf_index }}</span>
+              <span>{{ leaf.record_id }}</span>
+            </div>
+            <HashChip class="mt-2" :value="leaf.leaf_hash" />
+          </button>
+        </div>
+        <Button v-if="leafCursor" class="mt-3" size="sm" variant="subtle" :loading="loading" @click="loadLeaves(false)">加载更多叶子</Button>
+      </Card>
+
+      <div class="flex flex-col gap-4">
+        <Card title="Proof Path" subtitle="单条记录从 leaf 到 batch root 的审计路径">
+          <div class="flex flex-wrap gap-2 mb-4">
+            <input v-model="recordID" class="h-9 min-w-[280px] flex-1 px-3 rounded-[12px] border border-white/10 bg-[#0b0d0b]/80 text-[12px] text-ink-100" placeholder="record_id" @keyup.enter="submitProof" />
+            <Button size="sm" :loading="loading" @click="submitProof">查看 proof path</Button>
+          </div>
+          <ProofPathGraph :proof="proof" />
+        </Card>
+
+        <Card title="Tree Explorer" subtitle="按 level/start 分页读取真实批次 Merkle 节点">
+          <div class="flex flex-wrap gap-2 mb-4">
+            <input v-model.number="level" type="number" min="0" class="h-9 w-[110px] px-3 rounded-[12px] border border-white/10 bg-[#0b0d0b]/80 text-[12px] text-ink-100" placeholder="level" />
+            <input v-model.number="start" type="number" min="0" class="h-9 w-[130px] px-3 rounded-[12px] border border-white/10 bg-[#0b0d0b]/80 text-[12px] text-ink-100" placeholder="start" />
+            <Button size="sm" variant="subtle" :loading="loading" @click="loadNodes(true)">读取节点</Button>
+          </div>
+          <MerkleTreeExplorer :nodes="nodes" :next-cursor="nodeCursor" :loading="loading" @load-more="loadNodes(false)" />
+        </Card>
+      </div>
+    </div>
+  </div>
+</template>

--- a/clients/web/src/pages/Batches.test.ts
+++ b/clients/web/src/pages/Batches.test.ts
@@ -1,0 +1,22 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import Batches from './Batches.vue'
+
+vi.mock('vue-router', () => ({
+  RouterLink: { props: ['to'], template: '<a :href="to"><slot /></a>' },
+}))
+
+describe('Batches page', () => {
+  it('loads and displays batch history', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      roots: [{ batch_id: 'batch-a', tree_size: 2, closed_at_unix_nano: 1000, batch_root: [9] }],
+    }), { status: 200 })))
+
+    const wrapper = mount(Batches)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('batch-a')
+    expect(wrapper.text()).toContain('2')
+    vi.unstubAllGlobals()
+  })
+})

--- a/clients/web/src/pages/Batches.vue
+++ b/clients/web/src/pages/Batches.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { RouterLink } from 'vue-router'
+import Card from '@/components/Card.vue'
+import Button from '@/components/Button.vue'
+import HashChip from '@/components/HashChip.vue'
+import EmptyState from '@/components/EmptyState.vue'
+import { getBatches, type BatchRoot } from '@/lib/api'
+import { formatTime, nanoToDate } from '@/lib/format'
+import { GitBranch, RefreshCcw } from 'lucide-vue-next'
+
+const roots = ref<BatchRoot[]>([])
+const cursor = ref('')
+const loading = ref(false)
+const err = ref('')
+
+async function load(reset: boolean) {
+  if (reset) cursor.value = ''
+  loading.value = true
+  err.value = ''
+  try {
+    const body = await getBatches({ limit: 50, cursor: cursor.value })
+    roots.value = reset ? body.roots : roots.value.concat(body.roots)
+    cursor.value = body.next_cursor ?? ''
+  } catch (e: unknown) {
+    err.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => load(true))
+</script>
+
+<template>
+  <div class="flex flex-col gap-4 max-w-[1200px] mx-auto">
+    <Card title="历史批次" subtitle="GET /v1/batches，按 cursor 分页读取 batch roots">
+      <template #actions>
+        <Button size="sm" variant="subtle" :loading="loading" @click="load(true)">
+          <RefreshCcw :size="12" /> 刷新
+        </Button>
+      </template>
+      <p v-if="err" class="mb-3 text-[12px] text-danger">{{ err }}</p>
+      <EmptyState v-if="!roots.length && !loading" title="暂无批次" hint="提交记录后会生成 batch root。" :icon="GitBranch" />
+      <div v-else class="overflow-x-auto">
+        <table class="w-full text-[12px]">
+          <thead class="text-ink-500 text-left">
+            <tr>
+              <th class="py-2 font-normal">batch</th>
+              <th class="px-2 py-2 font-normal">tree size</th>
+              <th class="px-2 py-2 font-normal">closed</th>
+              <th class="px-2 py-2 font-normal">root</th>
+              <th class="py-2 font-normal text-right">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="root in roots" :key="root.batch_id" class="border-t border-[var(--hairline)]">
+              <td class="py-2"><HashChip :value="root.batch_id" :head="18" :tail="8" /></td>
+              <td class="px-2 py-2 text-ink-300 font-mono">{{ root.tree_size }}</td>
+              <td class="px-2 py-2 text-ink-400">{{ formatTime(nanoToDate(root.closed_at_unix_nano)) }}</td>
+              <td class="px-2 py-2"><HashChip :value="root.batch_root" :head="10" :tail="8" /></td>
+              <td class="py-2 text-right">
+                <RouterLink class="text-accent hover:underline" :to="`/batches/${encodeURIComponent(root.batch_id)}`">查看树</RouterLink>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div v-if="cursor" class="mt-4">
+        <Button size="sm" variant="subtle" :loading="loading" @click="load(false)">加载更多</Button>
+      </div>
+    </Card>
+  </div>
+</template>

--- a/clients/web/src/pages/GlobalTree.test.ts
+++ b/clients/web/src/pages/GlobalTree.test.ts
@@ -1,0 +1,20 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import GlobalTree from './GlobalTree.vue'
+
+describe('GlobalTree page', () => {
+  it('loads global tree summary, nodes and leaves', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, state: { tree_size: 2, root_hash: [9] }, sth: { tree_size: 2, root_hash: [9] } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ nodes: [{ schema_version: 'n', level: 0, start_index: 0, width: 1, hash: [1] }] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ leaves: [{ schema_version: 'l', batch_id: 'batch-a', leaf_index: 0, batch_tree_size: 2, leaf_hash: [1] }] }), { status: 200 })))
+
+    const wrapper = mount(GlobalTree)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('tree size')
+    expect(wrapper.text()).toContain('batch-a')
+    expect(wrapper.text()).toContain('L0 / start 0')
+    vi.unstubAllGlobals()
+  })
+})

--- a/clients/web/src/pages/GlobalTree.test.ts
+++ b/clients/web/src/pages/GlobalTree.test.ts
@@ -6,7 +6,6 @@ describe('GlobalTree page', () => {
   it('loads global tree summary, nodes and leaves', async () => {
     vi.stubGlobal('fetch', vi.fn()
       .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true, state: { tree_size: 2, root_hash: [9] }, sth: { tree_size: 2, root_hash: [9] } }), { status: 200 }))
-      .mockResolvedValueOnce(new Response(JSON.stringify({ nodes: [{ schema_version: 'n', level: 0, start_index: 0, width: 1, hash: [1] }] }), { status: 200 }))
       .mockResolvedValueOnce(new Response(JSON.stringify({ leaves: [{ schema_version: 'l', batch_id: 'batch-a', leaf_index: 0, batch_tree_size: 2, leaf_hash: [1] }] }), { status: 200 })))
 
     const wrapper = mount(GlobalTree)
@@ -14,7 +13,7 @@ describe('GlobalTree page', () => {
 
     expect(wrapper.text()).toContain('tree size')
     expect(wrapper.text()).toContain('batch-a')
-    expect(wrapper.text()).toContain('L0 / start 0')
+    expect(wrapper.text()).toContain('L1 / start 0')
     vi.unstubAllGlobals()
   })
 })

--- a/clients/web/src/pages/GlobalTree.vue
+++ b/clients/web/src/pages/GlobalTree.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import Card from '@/components/Card.vue'
 import Button from '@/components/Button.vue'
 import HashChip from '@/components/HashChip.vue'
@@ -8,6 +8,8 @@ import { getGlobalLeaves, getGlobalTree, getGlobalTreeNodes, type GlobalLogLeaf,
 import { formatTime, nanoToDate } from '@/lib/format'
 import { RefreshCcw } from 'lucide-vue-next'
 
+type ExpandableNode = Pick<GlobalLogNode, 'level' | 'start_index' | 'width'>
+
 const state = ref<GlobalLogState | null>(null)
 const sth = ref<SignedTreeHead | null>(null)
 const nodes = ref<GlobalLogNode[]>([])
@@ -15,8 +17,12 @@ const leaves = ref<GlobalLogLeaf[]>([])
 const nodeCursor = ref('')
 const leafCursor = ref('')
 const level = ref<number | undefined>()
+const start = ref<number | undefined>()
 const loading = ref(false)
 const err = ref('')
+
+const treeSize = computed(() => state.value?.tree_size ?? sth.value?.tree_size ?? 0)
+const rootHash = computed(() => state.value?.root_hash || sth.value?.root_hash || [])
 
 async function loadSummary() {
   const body = await getGlobalTree()
@@ -26,9 +32,85 @@ async function loadSummary() {
 
 async function loadNodes(reset: boolean) {
   if (reset) nodeCursor.value = ''
-  const body = await getGlobalTreeNodes({ level: level.value, limit: 40, cursor: nodeCursor.value })
+  const body = await getGlobalTreeNodes({ level: level.value, start: start.value, limit: 40, cursor: nodeCursor.value })
   nodes.value = reset ? body.nodes : nodes.value.concat(body.nodes)
   nodeCursor.value = body.next_cursor ?? ''
+}
+
+function rangeLevel(size: number): number {
+  if (size <= 1) return 0
+  let level = 0
+  let width = 1
+  while (width < size) {
+    width <<= 1
+    level += 1
+  }
+  return level
+}
+
+function largestPowerOfTwoLessThan(size: number): number {
+  let out = 1
+  while (out << 1 < size) out <<= 1
+  return out
+}
+
+function isPowerOfTwo(size: number): boolean {
+  return size > 0 && 2 ** Math.floor(Math.log2(size)) === size
+}
+
+function syntheticNode(level: number, start: number, width: number, hash: GlobalLogNode['hash'] = []): GlobalLogNode {
+  return {
+    schema_version: 'synthetic-global-node',
+    level,
+    start_index: start,
+    width,
+    hash,
+    created_at_unix_nano: 0,
+  }
+}
+
+function mergeNodes(incoming: GlobalLogNode[]) {
+  const map = new Map(nodes.value.map((node) => [`${node.level}:${node.start_index}:${node.width}`, node]))
+  for (const node of incoming) map.set(`${node.level}:${node.start_index}:${node.width}`, node)
+  nodes.value = [...map.values()]
+}
+
+async function loadRootNode() {
+  if (treeSize.value <= 0) {
+    nodes.value = []
+    nodeCursor.value = ''
+    return
+  }
+  nodes.value = [syntheticNode(rangeLevel(treeSize.value), 0, treeSize.value, rootHash.value)]
+  nodeCursor.value = ''
+}
+
+async function loadRangeNode(start: number, width: number): Promise<GlobalLogNode> {
+  const childLevel = rangeLevel(width)
+  if (isPowerOfTwo(width)) {
+    const body = await getGlobalTreeNodes({ level: childLevel, start, limit: 1 })
+    if (body.nodes[0]) return body.nodes[0]
+  }
+  return syntheticNode(childLevel, start, width)
+}
+
+async function expandNode(node: ExpandableNode) {
+  if (node.width <= 1) return
+  loading.value = true
+  err.value = ''
+  try {
+    const leftWidth = largestPowerOfTwoLessThan(node.width)
+    const rightWidth = node.width - leftWidth
+    const [left, right] = await Promise.all([
+      loadRangeNode(node.start_index, leftWidth),
+      loadRangeNode(node.start_index + leftWidth, rightWidth),
+    ])
+    mergeNodes([left, right])
+  } catch (e: unknown) {
+    err.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loading.value = false
+  }
 }
 
 async function loadLeaves(reset: boolean) {
@@ -43,7 +125,7 @@ async function refreshAll() {
   err.value = ''
   try {
     await loadSummary()
-    await loadNodes(true)
+      await loadRootNode()
     await loadLeaves(true)
   } catch (e: unknown) {
     err.value = e instanceof Error ? e.message : String(e)
@@ -84,9 +166,17 @@ onMounted(refreshAll)
       <Card title="全局节点" subtitle="读取已持久化的 GlobalLogNode，不重建整棵树">
         <div class="flex flex-wrap gap-2 mb-4">
           <input v-model.number="level" type="number" min="0" class="h-9 w-[130px] px-3 rounded-[12px] border border-white/10 bg-[#0b0d0b]/80 text-[12px] text-ink-100" placeholder="可选 level" />
+          <input v-model.number="start" type="number" min="0" class="h-9 w-[130px] px-3 rounded-[12px] border border-white/10 bg-[#0b0d0b]/80 text-[12px] text-ink-100" placeholder="可选 start" />
           <Button size="sm" variant="subtle" :loading="loading" @click="loadNodes(true)">读取节点</Button>
         </div>
-        <MerkleTreeExplorer :nodes="nodes" :next-cursor="nodeCursor" :loading="loading" @load-more="loadNodes(false)" />
+        <MerkleTreeExplorer
+          :nodes="nodes"
+          :tree-size="treeSize"
+          :next-cursor="nodeCursor"
+          :loading="loading"
+          @load-more="loadNodes(false)"
+          @expand="expandNode"
+        />
       </Card>
 
       <Card title="全局 leaves" subtitle="每个 leaf 对应一个 committed batch">

--- a/clients/web/src/pages/GlobalTree.vue
+++ b/clients/web/src/pages/GlobalTree.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import Card from '@/components/Card.vue'
+import Button from '@/components/Button.vue'
+import HashChip from '@/components/HashChip.vue'
+import MerkleTreeExplorer from '@/components/MerkleTreeExplorer.vue'
+import { getGlobalLeaves, getGlobalTree, getGlobalTreeNodes, type GlobalLogLeaf, type GlobalLogNode, type GlobalLogState, type SignedTreeHead } from '@/lib/api'
+import { formatTime, nanoToDate } from '@/lib/format'
+import { RefreshCcw } from 'lucide-vue-next'
+
+const state = ref<GlobalLogState | null>(null)
+const sth = ref<SignedTreeHead | null>(null)
+const nodes = ref<GlobalLogNode[]>([])
+const leaves = ref<GlobalLogLeaf[]>([])
+const nodeCursor = ref('')
+const leafCursor = ref('')
+const level = ref<number | undefined>()
+const loading = ref(false)
+const err = ref('')
+
+async function loadSummary() {
+  const body = await getGlobalTree()
+  state.value = body.state ?? null
+  sth.value = body.sth ?? null
+}
+
+async function loadNodes(reset: boolean) {
+  if (reset) nodeCursor.value = ''
+  const body = await getGlobalTreeNodes({ level: level.value, limit: 40, cursor: nodeCursor.value })
+  nodes.value = reset ? body.nodes : nodes.value.concat(body.nodes)
+  nodeCursor.value = body.next_cursor ?? ''
+}
+
+async function loadLeaves(reset: boolean) {
+  if (reset) leafCursor.value = ''
+  const body = await getGlobalLeaves({ limit: 30, cursor: leafCursor.value })
+  leaves.value = reset ? body.leaves : leaves.value.concat(body.leaves)
+  leafCursor.value = body.next_cursor ?? ''
+}
+
+async function refreshAll() {
+  loading.value = true
+  err.value = ''
+  try {
+    await loadSummary()
+    await loadNodes(true)
+    await loadLeaves(true)
+  } catch (e: unknown) {
+    err.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(refreshAll)
+</script>
+
+<template>
+  <div class="flex flex-col gap-4 max-w-[1280px] mx-auto">
+    <Card title="全局 Merkle Tree" subtitle="Global transparency log，按节点和 leaf 分页浏览">
+      <template #actions>
+        <Button size="sm" variant="subtle" :loading="loading" @click="refreshAll">
+          <RefreshCcw :size="12" /> 刷新
+        </Button>
+      </template>
+      <p v-if="err" class="mb-3 text-[12px] text-danger">{{ err }}</p>
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-3 text-[12px]">
+        <div class="rounded-[14px] bg-white/[0.03] border border-white/10 p-3">
+          <div class="kicker text-[9px]">tree size</div>
+          <div class="mt-1 font-mono text-accent">{{ state?.tree_size ?? '—' }}</div>
+        </div>
+        <div class="rounded-[14px] bg-white/[0.03] border border-white/10 p-3">
+          <div class="kicker text-[9px]">latest STH</div>
+          <div class="mt-1 text-ink-300">{{ formatTime(nanoToDate(sth?.timestamp_unix_nano)) || '—' }}</div>
+        </div>
+        <div class="rounded-[14px] bg-white/[0.03] border border-white/10 p-3">
+          <div class="kicker text-[9px]">root</div>
+          <div class="mt-1"><HashChip :value="sth?.root_hash || state?.root_hash" /></div>
+        </div>
+      </div>
+    </Card>
+
+    <div class="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_380px] gap-4">
+      <Card title="全局节点" subtitle="读取已持久化的 GlobalLogNode，不重建整棵树">
+        <div class="flex flex-wrap gap-2 mb-4">
+          <input v-model.number="level" type="number" min="0" class="h-9 w-[130px] px-3 rounded-[12px] border border-white/10 bg-[#0b0d0b]/80 text-[12px] text-ink-100" placeholder="可选 level" />
+          <Button size="sm" variant="subtle" :loading="loading" @click="loadNodes(true)">读取节点</Button>
+        </div>
+        <MerkleTreeExplorer :nodes="nodes" :next-cursor="nodeCursor" :loading="loading" @load-more="loadNodes(false)" />
+      </Card>
+
+      <Card title="全局 leaves" subtitle="每个 leaf 对应一个 committed batch">
+        <div class="space-y-2 max-h-[620px] overflow-y-auto pr-1">
+          <div v-for="leaf in leaves" :key="leaf.leaf_index" class="rounded-[12px] border border-white/10 bg-[#070807]/80 p-3">
+            <div class="flex justify-between gap-2 text-[11px] text-ink-400">
+              <span>#{{ leaf.leaf_index }}</span>
+              <span>batch size {{ leaf.batch_tree_size }}</span>
+            </div>
+            <div class="mt-1 text-[11px] font-mono text-ink-300 break-all">{{ leaf.batch_id }}</div>
+            <HashChip class="mt-2" :value="leaf.leaf_hash" />
+          </div>
+        </div>
+        <Button v-if="leafCursor" class="mt-3" size="sm" variant="subtle" :loading="loading" @click="loadLeaves(false)">加载更多 leaves</Button>
+      </Card>
+    </div>
+  </div>
+</template>

--- a/clients/web/src/router.ts
+++ b/clients/web/src/router.ts
@@ -7,6 +7,9 @@ const routes: RouteRecordRaw[] = [
   { path: '/dashboard', name: 'dashboard', component: () => import('./pages/Dashboard.vue'), meta: { title: '概览' } },
   { path: '/metrics', name: 'metrics', component: () => import('./pages/Metrics.vue'), meta: { title: '指标' } },
   { path: '/records', name: 'records', component: () => import('./pages/Records.vue'), meta: { title: '记录' } },
+  { path: '/batches', name: 'batches', component: () => import('./pages/Batches.vue'), meta: { title: '批次' } },
+  { path: '/batches/:batchID', name: 'batch-detail', component: () => import('./pages/BatchDetail.vue'), meta: { title: '批次详情' } },
+  { path: '/global-tree', name: 'global-tree', component: () => import('./pages/GlobalTree.vue'), meta: { title: '全局树' } },
   { path: '/settings', name: 'settings', component: () => import('./pages/Settings.vue'), meta: { title: '系统设置' } },
 ]
 

--- a/clients/web/src/test/setup.ts
+++ b/clients/web/src/test/setup.ts
@@ -1,5 +1,27 @@
 import { afterEach, vi } from 'vitest'
 
+const canvasContext = {
+  setTransform: vi.fn(),
+  clearRect: vi.fn(),
+  createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+  fillRect: vi.fn(),
+  beginPath: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+  stroke: vi.fn(),
+  bezierCurveTo: vi.fn(),
+  arc: vi.fn(),
+  fill: vi.fn(),
+  closePath: vi.fn(),
+  arcTo: vi.fn(),
+  fillText: vi.fn(),
+}
+
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  value: vi.fn(() => canvasContext),
+  configurable: true,
+})
+
 afterEach(() => {
   vi.clearAllMocks()
 })

--- a/clients/web/tests/e2e/admin.spec.ts
+++ b/clients/web/tests/e2e/admin.spec.ts
@@ -86,6 +86,54 @@ async function mockAdminAPI(page: Page) {
     await route.fulfill({ json: { batch_id: 'batch-1', tree_size: 2 } })
   })
 
+  await page.route('**/admin/api/proxy/v1/batches?*', async (route) => {
+    await route.fulfill({ json: { roots: [{ batch_id: 'batch-1', tree_size: 2, closed_at_unix_nano: 1_700_000_000_000_000_000, batch_root: [9] }] } })
+  })
+
+  await page.route('**/admin/api/proxy/v1/batches/batch-1', async (route) => {
+    await route.fulfill({
+      json: {
+        root: { batch_id: 'batch-1', tree_size: 2, closed_at_unix_nano: 1_700_000_000_000_000_000, batch_root: [9] },
+        manifest: { batch_id: 'batch-1', state: 'committed', tree_size: 2, batch_root: [9], record_ids: ['record-abcdef123456'] },
+        record_count: 1,
+      },
+    })
+  })
+
+  await page.route('**/admin/api/proxy/v1/batches/batch-1/tree/leaves?*', async (route) => {
+    await route.fulfill({ json: { leaves: [{ batch_id: 'batch-1', record_id: 'record-abcdef123456', leaf_index: 0, leaf_hash: [1] }] } })
+  })
+
+  await page.route('**/admin/api/proxy/v1/batches/batch-1/tree/nodes?*', async (route) => {
+    await route.fulfill({ json: { nodes: [{ batch_id: 'batch-1', level: 0, start_index: 0, width: 1, hash: [1] }, { batch_id: 'batch-1', level: 1, start_index: 0, width: 2, hash: [9] }] } })
+  })
+
+  await page.route('**/admin/api/proxy/v1/proofs/record-abcdef123456', async (route) => {
+    await route.fulfill({
+      json: {
+        record_id: 'record-abcdef123456',
+        proof_level: 'L5',
+        proof_bundle: {
+          record_id: 'record-abcdef123456',
+          committed_receipt: { batch_id: 'batch-1', leaf_index: 0, leaf_hash: [1], batch_root: [9], batch_closed_at_unix_nano: 1_700_000_000_000_000_000 },
+          batch_proof: { tree_alg: 'rfc6962-sha256', leaf_index: 0, tree_size: 2, audit_path: [[2]] },
+        },
+      },
+    })
+  })
+
+  await page.route('**/admin/api/proxy/v1/global-log/tree', async (route) => {
+    await route.fulfill({ json: { ok: true, state: { tree_size: 1, root_hash: [9] }, sth: { tree_size: 1, root_hash: [9], timestamp_unix_nano: 1_700_000_000_000_000_000 } } })
+  })
+
+  await page.route('**/admin/api/proxy/v1/global-log/tree/nodes?*', async (route) => {
+    await route.fulfill({ json: { nodes: [{ level: 0, start_index: 0, width: 1, hash: [9] }] } })
+  })
+
+  await page.route('**/admin/api/proxy/v1/global-log/tree/leaves?*', async (route) => {
+    await route.fulfill({ json: { leaves: [{ batch_id: 'batch-1', leaf_index: 0, batch_tree_size: 2, leaf_hash: [9] }] } })
+  })
+
   await page.route('**/admin/api/proxy/v1/records?*', async (route) => {
     await route.fulfill({
       json: {
@@ -152,4 +200,26 @@ test('loads settings and saves YAML through the config endpoint', async ({ page 
   await expect(page.locator('textarea')).toHaveValue(/admin:/)
   await page.getByRole('button', { name: '保存 YAML' }).click()
   await expect(page.getByText(/已保存/)).toBeVisible()
+})
+
+test('shows batch and global merkle visualizations', async ({ page }) => {
+  await page.goto('/admin/login')
+  await page.locator('input').nth(0).fill('ops')
+  await page.locator('input').nth(1).fill('secret')
+  await page.getByRole('button', { name: '登录' }).click()
+
+  await page.getByRole('link', { name: /批次/ }).click()
+  await expect(page.getByRole('heading', { name: '历史批次' })).toBeVisible()
+  await expect(page.getByText('batch-1')).toBeVisible()
+  await page.getByRole('link', { name: '查看树' }).click()
+  await expect(page.getByRole('heading', { name: '批次详情' })).toBeVisible()
+  await expect(page.getByText('Tree Explorer')).toBeVisible()
+  await page.getByText('record-abcdef123456').click()
+  await page.getByRole('button', { name: '查看 proof path' }).click()
+  await expect(page.getByText('Sibling 1')).toBeVisible()
+
+  await page.getByRole('link', { name: /全局树/ }).click()
+  await expect(page.getByRole('heading', { name: '全局 Merkle Tree' })).toBeVisible()
+  await expect(page.getByText('全局节点')).toBeVisible()
+  await expect(page.getByText('batch-1')).toBeVisible()
 })

--- a/internal/batch/service.go
+++ b/internal/batch/service.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ryan-wong-coder/trustdb/internal/merkle"
 	"github.com/ryan-wong-coder/trustdb/internal/model"
 	"github.com/ryan-wong-coder/trustdb/internal/observability"
 	"github.com/ryan-wong-coder/trustdb/internal/proofstore"
@@ -39,6 +40,9 @@ type Store interface {
 	ListRootsAfter(context.Context, int64, int) ([]model.BatchRoot, error)
 	ListRootsPage(context.Context, model.RootListOptions) ([]model.BatchRoot, error)
 	LatestRoot(context.Context) (model.BatchRoot, error)
+	PutBatchTreeArtifacts(context.Context, []model.BatchTreeLeaf, []model.BatchTreeNode) error
+	ListBatchTreeLeaves(context.Context, model.BatchTreeLeafListOptions) ([]model.BatchTreeLeaf, error)
+	ListBatchTreeNodes(context.Context, model.BatchTreeNodeListOptions) ([]model.BatchTreeNode, error)
 	PutManifest(context.Context, model.BatchManifest) error
 	GetManifest(context.Context, string) (model.BatchManifest, error)
 	ListManifests(context.Context) ([]model.BatchManifest, error)
@@ -282,6 +286,27 @@ func (s *Service) LatestRoot(ctx context.Context) (model.BatchRoot, error) {
 	return s.store.LatestRoot(ctx)
 }
 
+func (s *Service) Manifest(ctx context.Context, batchID string) (model.BatchManifest, error) {
+	if s.store == nil {
+		return model.BatchManifest{}, trusterr.New(trusterr.CodeFailedPrecondition, "proof store is not configured")
+	}
+	return s.store.GetManifest(ctx, batchID)
+}
+
+func (s *Service) BatchTreeLeaves(ctx context.Context, opts model.BatchTreeLeafListOptions) ([]model.BatchTreeLeaf, error) {
+	if s.store == nil {
+		return nil, trusterr.New(trusterr.CodeFailedPrecondition, "proof store is not configured")
+	}
+	return s.store.ListBatchTreeLeaves(ctx, opts)
+}
+
+func (s *Service) BatchTreeNodes(ctx context.Context, opts model.BatchTreeNodeListOptions) ([]model.BatchTreeNode, error) {
+	if s.store == nil {
+		return nil, trusterr.New(trusterr.CodeFailedPrecondition, "proof store is not configured")
+	}
+	return s.store.ListBatchTreeNodes(ctx, opts)
+}
+
 func (s *Service) Manifests(ctx context.Context) ([]model.BatchManifest, error) {
 	if s.store == nil {
 		return nil, trusterr.New(trusterr.CodeFailedPrecondition, "proof store is not configured")
@@ -432,6 +457,10 @@ func (s *Service) persistBatch(ctx context.Context, batchID string, closedAt tim
 	if err != nil {
 		return trusterr.Wrap(trusterr.CodeInternal, "commit batch", err)
 	}
+	leaves, nodes, err := buildBatchTreeArtifacts(batchID, root, records)
+	if err != nil {
+		return trusterr.Wrap(trusterr.CodeInternal, "build batch tree artifacts", err)
+	}
 
 	manifest := model.BatchManifest{
 		SchemaVersion:   model.SchemaBatchManifest,
@@ -459,6 +488,10 @@ func (s *Service) persistBatch(ctx context.Context, batchID string, closedAt tim
 			s.observeBatchStage("artifacts", stageStart)
 			return err
 		}
+		if err := s.store.PutBatchTreeArtifacts(ctx, leaves, nodes); err != nil {
+			s.observeBatchStage("artifacts", stageStart)
+			return err
+		}
 		s.observeBatchStage("artifacts", stageStart)
 		itemsCopy := cloneAcceptedItems(items)
 		if s.opts.ProofMode == ProofModeAsync {
@@ -471,6 +504,9 @@ func (s *Service) persistBatch(ctx context.Context, batchID string, closedAt tim
 	root, err = s.writeBundlesAndRoot(ctx, batchID, bundles)
 	s.observeBatchStage("artifacts", stageStart)
 	if err != nil {
+		return err
+	}
+	if err := s.store.PutBatchTreeArtifacts(ctx, leaves, nodes); err != nil {
 		return err
 	}
 	manifest.State = model.BatchStateCommitted
@@ -513,6 +549,47 @@ func (s *Service) writeBundlesAndRoot(ctx context.Context, batchID string, bundl
 		return model.BatchRoot{}, err
 	}
 	return root, nil
+}
+
+func buildBatchTreeArtifacts(batchID string, root model.BatchRoot, records []model.ServerRecord) ([]model.BatchTreeLeaf, []model.BatchTreeNode, error) {
+	tree, err := merkle.Build(records)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(root.BatchRoot) > 0 && !bytes.Equal(root.BatchRoot, tree.Root()) {
+		return nil, nil, trusterr.New(trusterr.CodeDataLoss, "batch tree root does not match committed batch root")
+	}
+	now := time.Now().UTC().UnixNano()
+	rawLeaves := tree.Leaves()
+	leaves := make([]model.BatchTreeLeaf, len(rawLeaves))
+	for i := range rawLeaves {
+		recordID := ""
+		if int(rawLeaves[i].Index) < len(records) {
+			recordID = records[rawLeaves[i].Index].RecordID
+		}
+		leaves[i] = model.BatchTreeLeaf{
+			SchemaVersion:  model.SchemaBatchTreeLeaf,
+			BatchID:        batchID,
+			RecordID:       recordID,
+			LeafIndex:      rawLeaves[i].Index,
+			LeafHash:       append([]byte(nil), rawLeaves[i].Hash...),
+			CreatedAtUnixN: now,
+		}
+	}
+	rawNodes := tree.Nodes()
+	nodes := make([]model.BatchTreeNode, len(rawNodes))
+	for i := range rawNodes {
+		nodes[i] = model.BatchTreeNode{
+			SchemaVersion:  model.SchemaBatchTreeNode,
+			BatchID:        batchID,
+			Level:          rawNodes[i].Level,
+			StartIndex:     rawNodes[i].StartIndex,
+			Width:          rawNodes[i].Width,
+			Hash:           append([]byte(nil), rawNodes[i].Hash...),
+			CreatedAtUnixN: now,
+		}
+	}
+	return leaves, nodes, nil
 }
 
 func rootFromBundles(batchID string, bundles []model.ProofBundle) model.BatchRoot {
@@ -584,7 +661,7 @@ func (s *Service) RecoverManifest(ctx context.Context, manifest model.BatchManif
 		}
 	}
 	if s.opts.ProofMode == ProofModeOnDemand {
-		root, indexes, err := s.planBatchIndexesFromItems(manifest.BatchID, time.Unix(0, manifest.ClosedAtUnixN).UTC(), items)
+		root, indexes, records, err := s.planBatchIndexesFromItems(manifest.BatchID, time.Unix(0, manifest.ClosedAtUnixN).UTC(), items)
 		if err != nil {
 			return trusterr.Wrap(trusterr.CodeInternal, "rebuild on-demand batch indexes during recovery", err)
 		}
@@ -592,6 +669,13 @@ func (s *Service) RecoverManifest(ctx context.Context, manifest model.BatchManif
 			return trusterr.New(trusterr.CodeDataLoss, "recovered on-demand batch root does not match prepared manifest")
 		}
 		if err := s.writeIndexesAndRoot(ctx, indexes, root); err != nil {
+			return err
+		}
+		leaves, nodes, err := buildBatchTreeArtifacts(manifest.BatchID, root, records)
+		if err != nil {
+			return err
+		}
+		if err := s.store.PutBatchTreeArtifacts(ctx, leaves, nodes); err != nil {
 			return err
 		}
 		return nil
@@ -673,6 +757,13 @@ func (s *Service) materializeManifest(ctx context.Context, manifest model.BatchM
 	if err != nil {
 		return model.BatchRoot{}, err
 	}
+	leaves, nodes, err := buildBatchTreeArtifacts(manifest.BatchID, root, records)
+	if err != nil {
+		return model.BatchRoot{}, err
+	}
+	if err := s.store.PutBatchTreeArtifacts(ctx, leaves, nodes); err != nil {
+		return model.BatchRoot{}, err
+	}
 	manifest.State = model.BatchStateCommitted
 	if manifest.CommittedAtUnixN == 0 {
 		manifest.CommittedAtUnixN = time.Now().UTC().UnixNano()
@@ -688,9 +779,10 @@ func (s *Service) materializeManifest(ctx context.Context, manifest model.BatchM
 	return root, nil
 }
 
-func (s *Service) planBatchIndexesFromItems(batchID string, closedAt time.Time, items []Accepted) (model.BatchRoot, []model.RecordIndex, error) {
+func (s *Service) planBatchIndexesFromItems(batchID string, closedAt time.Time, items []Accepted) (model.BatchRoot, []model.RecordIndex, []model.ServerRecord, error) {
 	signed, records, accepted := splitAcceptedItems(items)
-	return s.planBatchIndexes(batchID, closedAt, signed, records, accepted)
+	root, indexes, err := s.planBatchIndexes(batchID, closedAt, signed, records, accepted)
+	return root, indexes, records, err
 }
 
 func splitAcceptedItems(items []Accepted) ([]model.SignedClaim, []model.ServerRecord, []model.AcceptedReceipt) {

--- a/internal/batch/service_bench_test.go
+++ b/internal/batch/service_bench_test.go
@@ -151,6 +151,18 @@ func (benchmarkBatchStore) LatestRoot(context.Context) (model.BatchRoot, error) 
 	return model.BatchRoot{}, trusterr.New(trusterr.CodeNotFound, "batch root not found")
 }
 
+func (benchmarkBatchStore) PutBatchTreeArtifacts(context.Context, []model.BatchTreeLeaf, []model.BatchTreeNode) error {
+	return nil
+}
+
+func (benchmarkBatchStore) ListBatchTreeLeaves(context.Context, model.BatchTreeLeafListOptions) ([]model.BatchTreeLeaf, error) {
+	return nil, nil
+}
+
+func (benchmarkBatchStore) ListBatchTreeNodes(context.Context, model.BatchTreeNodeListOptions) ([]model.BatchTreeNode, error) {
+	return nil, nil
+}
+
 func (benchmarkBatchStore) PutManifest(context.Context, model.BatchManifest) error { return nil }
 
 func (benchmarkBatchStore) GetManifest(context.Context, string) (model.BatchManifest, error) {

--- a/internal/batch/service_test.go
+++ b/internal/batch/service_test.go
@@ -1,7 +1,6 @@
 package batch
 
 import (
-	"bytes"
 	"context"
 	"strings"
 	"sync"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
+	"github.com/ryan-wong-coder/trustdb/internal/merkle"
 	"github.com/ryan-wong-coder/trustdb/internal/model"
 	"github.com/ryan-wong-coder/trustdb/internal/observability"
 	"github.com/ryan-wong-coder/trustdb/internal/proofstore"
@@ -40,8 +40,19 @@ func TestServiceCommitsFullBatch(t *testing.T) {
 	// visible to Proof() does not yet imply the root file has landed.
 	// Poll briefly to close that window instead of asserting immediately.
 	root := waitForLatestRoot(t, svc, 2)
-	if !bytes.Equal(root.BatchRoot, bytes.Repeat([]byte{9}, 32)) {
+	if len(root.BatchRoot) != 32 {
 		t.Fatalf("LatestRoot() = %+v", root)
+	}
+	leaves := waitForBatchTreeLeaves(t, store, root.BatchID, 2)
+	if len(leaves) != 2 || leaves[0].RecordID != "tr1a" || leaves[1].RecordID != "tr1b" {
+		t.Fatalf("ListBatchTreeLeaves() = %+v", leaves)
+	}
+	nodes, err := store.ListBatchTreeNodes(context.Background(), model.BatchTreeNodeListOptions{BatchID: root.BatchID, Level: 1, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListBatchTreeNodes() error = %v", err)
+	}
+	if len(nodes) != 1 || nodes[0].Width != 2 {
+		t.Fatalf("ListBatchTreeNodes() = %+v", nodes)
 	}
 }
 
@@ -468,6 +479,21 @@ func waitForLatestRoot(t *testing.T, svc *Service, wantTreeSize uint64) model.Ba
 	return model.BatchRoot{}
 }
 
+func waitForBatchTreeLeaves(t *testing.T, store proofstore.LocalStore, batchID string, want int) []model.BatchTreeLeaf {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		leaves, err := store.ListBatchTreeLeaves(context.Background(), model.BatchTreeLeafListOptions{BatchID: batchID, Limit: want})
+		if err == nil && len(leaves) >= want {
+			return leaves
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	leaves, err := store.ListBatchTreeLeaves(context.Background(), model.BatchTreeLeafListOptions{BatchID: batchID, Limit: want})
+	t.Fatalf("ListBatchTreeLeaves(%q) after wait = %+v err=%v want len=%d", batchID, leaves, err, want)
+	return nil
+}
+
 func waitForProof(t *testing.T, svc *Service, recordID string) model.ProofBundle {
 	t.Helper()
 	deadline := time.Now().Add(asyncProofWaitTimeout)
@@ -487,8 +513,20 @@ type fakeEngine struct{}
 
 func (fakeEngine) CommitBatch(batchID string, closedAt time.Time, signed []model.SignedClaim, records []model.ServerRecord, accepted []model.AcceptedReceipt) ([]model.ProofBundle, error) {
 	out := make([]model.ProofBundle, len(records))
-	root := bytes.Repeat([]byte{9}, 32)
+	tree, err := merkle.Build(records)
+	if err != nil {
+		return nil, err
+	}
+	root := tree.Root()
 	for i := range records {
+		leaf, err := tree.LeafHash(i)
+		if err != nil {
+			return nil, err
+		}
+		proof, err := tree.Proof(i)
+		if err != nil {
+			return nil, err
+		}
 		out[i] = model.ProofBundle{
 			SchemaVersion:   model.SchemaProofBundle,
 			RecordID:        records[i].RecordID,
@@ -501,6 +539,7 @@ func (fakeEngine) CommitBatch(batchID string, closedAt time.Time, signed []model
 				Status:        "committed",
 				BatchID:       batchID,
 				LeafIndex:     uint64(i),
+				LeafHash:      leaf,
 				BatchRoot:     root,
 				ClosedAtUnixN: closedAt.UnixNano(),
 			},
@@ -508,6 +547,7 @@ func (fakeEngine) CommitBatch(batchID string, closedAt time.Time, signed []model
 				TreeAlg:   model.DefaultMerkleTreeAlg,
 				LeafIndex: uint64(i),
 				TreeSize:  uint64(len(records)),
+				AuditPath: proof,
 			},
 		}
 	}

--- a/internal/globallog/history_bench_test.go
+++ b/internal/globallog/history_bench_test.go
@@ -369,6 +369,10 @@ func (s *countingGlobalStore) GetGlobalLogNode(ctx context.Context, level, start
 	return s.base.GetGlobalLogNode(ctx, level, startIndex)
 }
 
+func (s *countingGlobalStore) ListGlobalLogNodesAfter(ctx context.Context, afterLevel, afterStartIndex uint64, limit int) ([]model.GlobalLogNode, error) {
+	return s.base.ListGlobalLogNodesAfter(ctx, afterLevel, afterStartIndex, limit)
+}
+
 func (s *countingGlobalStore) PutGlobalLogState(ctx context.Context, state model.GlobalLogState) error {
 	return s.base.PutGlobalLogState(ctx, state)
 }
@@ -564,6 +568,37 @@ func (s *memoryGlobalStore) GetGlobalLogNode(ctx context.Context, level, startIn
 	defer s.mu.RUnlock()
 	node, ok := s.nodes[globalNodeKey{level: level, start: startIndex}]
 	return cloneGlobalLogNode(node), ok, nil
+}
+
+func (s *memoryGlobalStore) ListGlobalLogNodesAfter(ctx context.Context, afterLevel, afterStartIndex uint64, limit int) ([]model.GlobalLogNode, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "memory global node list canceled", err)
+	}
+	limit = normaliseMemoryLimit(limit)
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	keys := make([]globalNodeKey, 0, len(s.nodes))
+	for key := range s.nodes {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].level == keys[j].level {
+			return keys[i].start < keys[j].start
+		}
+		return keys[i].level < keys[j].level
+	})
+	hasCursor := afterLevel != ^uint64(0) || afterStartIndex != ^uint64(0)
+	out := make([]model.GlobalLogNode, 0, limit)
+	for _, key := range keys {
+		if hasCursor && (key.level < afterLevel || key.level == afterLevel && key.start <= afterStartIndex) {
+			continue
+		}
+		out = append(out, cloneGlobalLogNode(s.nodes[key]))
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
 }
 
 func (s *memoryGlobalStore) PutGlobalLogState(ctx context.Context, state model.GlobalLogState) error {

--- a/internal/globallog/service.go
+++ b/internal/globallog/service.go
@@ -198,6 +198,10 @@ func (s *Service) State(ctx context.Context) (model.GlobalLogState, bool, error)
 	return s.store.GetGlobalLogState(ctx)
 }
 
+func (s *Service) Node(ctx context.Context, level, startIndex uint64) (model.GlobalLogNode, bool, error) {
+	return s.store.GetGlobalLogNode(ctx, level, startIndex)
+}
+
 func (s *Service) ListNodesAfter(ctx context.Context, afterLevel, afterStartIndex uint64, limit int) ([]model.GlobalLogNode, error) {
 	return s.store.ListGlobalLogNodesAfter(ctx, afterLevel, afterStartIndex, limit)
 }

--- a/internal/globallog/service.go
+++ b/internal/globallog/service.go
@@ -32,6 +32,7 @@ type Store interface {
 	ListGlobalLeavesPage(context.Context, model.GlobalLeafListOptions) ([]model.GlobalLogLeaf, error)
 	PutGlobalLogNode(context.Context, model.GlobalLogNode) error
 	GetGlobalLogNode(context.Context, uint64, uint64) (model.GlobalLogNode, bool, error)
+	ListGlobalLogNodesAfter(context.Context, uint64, uint64, int) ([]model.GlobalLogNode, error)
 	PutGlobalLogState(context.Context, model.GlobalLogState) error
 	GetGlobalLogState(context.Context) (model.GlobalLogState, bool, error)
 	PutSignedTreeHead(context.Context, model.SignedTreeHead) error
@@ -191,6 +192,14 @@ func (s *Service) ListSTHs(ctx context.Context, opts model.TreeHeadListOptions) 
 
 func (s *Service) ListLeaves(ctx context.Context, opts model.GlobalLeafListOptions) ([]model.GlobalLogLeaf, error) {
 	return s.store.ListGlobalLeavesPage(ctx, opts)
+}
+
+func (s *Service) State(ctx context.Context) (model.GlobalLogState, bool, error) {
+	return s.store.GetGlobalLogState(ctx)
+}
+
+func (s *Service) ListNodesAfter(ctx context.Context, afterLevel, afterStartIndex uint64, limit int) ([]model.GlobalLogNode, error) {
+	return s.store.ListGlobalLogNodesAfter(ctx, afterLevel, afterStartIndex, limit)
 }
 
 func (s *Service) InclusionProof(ctx context.Context, batchID string, treeSize uint64) (model.GlobalLogProof, error) {

--- a/internal/grpcapi/server_test.go
+++ b/internal/grpcapi/server_test.go
@@ -41,6 +41,14 @@ func (*typedNilGlobalService) ListLeaves(context.Context, model.GlobalLeafListOp
 	panic("typed nil global service should be normalized before use")
 }
 
+func (*typedNilGlobalService) State(context.Context) (model.GlobalLogState, bool, error) {
+	panic("typed nil global service should be normalized before use")
+}
+
+func (*typedNilGlobalService) ListNodesAfter(context.Context, uint64, uint64, int) ([]model.GlobalLogNode, error) {
+	panic("typed nil global service should be normalized before use")
+}
+
 func (*typedNilGlobalService) InclusionProof(context.Context, string, uint64) (model.GlobalLogProof, error) {
 	panic("typed nil global service should be normalized before use")
 }

--- a/internal/grpcapi/server_test.go
+++ b/internal/grpcapi/server_test.go
@@ -45,6 +45,10 @@ func (*typedNilGlobalService) State(context.Context) (model.GlobalLogState, bool
 	panic("typed nil global service should be normalized before use")
 }
 
+func (*typedNilGlobalService) Node(context.Context, uint64, uint64) (model.GlobalLogNode, bool, error) {
+	panic("typed nil global service should be normalized before use")
+}
+
 func (*typedNilGlobalService) ListNodesAfter(context.Context, uint64, uint64, int) ([]model.GlobalLogNode, error) {
 	panic("typed nil global service should be normalized before use")
 }

--- a/internal/httpapi/handler.go
+++ b/internal/httpapi/handler.go
@@ -41,6 +41,9 @@ type BatchService interface {
 	RootsAfter(context.Context, int64, int) ([]model.BatchRoot, error)
 	RootsPage(context.Context, model.RootListOptions) ([]model.BatchRoot, error)
 	LatestRoot(context.Context) (model.BatchRoot, error)
+	Manifest(context.Context, string) (model.BatchManifest, error)
+	BatchTreeLeaves(context.Context, model.BatchTreeLeafListOptions) ([]model.BatchTreeLeaf, error)
+	BatchTreeNodes(context.Context, model.BatchTreeNodeListOptions) ([]model.BatchTreeNode, error)
 }
 
 // AnchorService is the tiny surface the HTTP layer needs to expose
@@ -57,6 +60,8 @@ type GlobalLogService interface {
 	STH(context.Context, uint64) (model.SignedTreeHead, bool, error)
 	ListSTHs(context.Context, model.TreeHeadListOptions) ([]model.SignedTreeHead, error)
 	ListLeaves(context.Context, model.GlobalLeafListOptions) ([]model.GlobalLogLeaf, error)
+	State(context.Context) (model.GlobalLogState, bool, error)
+	ListNodesAfter(context.Context, uint64, uint64, int) ([]model.GlobalLogNode, error)
 	InclusionProof(context.Context, string, uint64) (model.GlobalLogProof, error)
 	ConsistencyProof(context.Context, uint64, uint64) (model.GlobalConsistencyProof, error)
 }
@@ -89,6 +94,24 @@ type rootsResponse struct {
 	NextCursor string            `json:"next_cursor,omitempty"`
 }
 
+type batchResponse struct {
+	Root        model.BatchRoot     `json:"root"`
+	Manifest    model.BatchManifest `json:"manifest"`
+	RecordCount int                 `json:"record_count"`
+}
+
+type batchLeavesResponse struct {
+	Leaves     []model.BatchTreeLeaf `json:"leaves"`
+	Limit      int                   `json:"limit"`
+	NextCursor string                `json:"next_cursor,omitempty"`
+}
+
+type batchNodesResponse struct {
+	Nodes      []model.BatchTreeNode `json:"nodes"`
+	Limit      int                   `json:"limit"`
+	NextCursor string                `json:"next_cursor,omitempty"`
+}
+
 type recordsResponse struct {
 	Records    []model.RecordIndex `json:"records"`
 	Limit      int                 `json:"limit"`
@@ -107,6 +130,18 @@ type globalLeavesResponse struct {
 	Leaves     []model.GlobalLogLeaf `json:"leaves"`
 	Limit      int                   `json:"limit"`
 	Direction  string                `json:"direction"`
+	NextCursor string                `json:"next_cursor,omitempty"`
+}
+
+type globalTreeResponse struct {
+	STH   *model.SignedTreeHead `json:"sth,omitempty"`
+	State model.GlobalLogState  `json:"state"`
+	OK    bool                  `json:"ok"`
+}
+
+type globalNodesResponse struct {
+	Nodes      []model.GlobalLogNode `json:"nodes"`
+	Limit      int                   `json:"limit"`
 	NextCursor string                `json:"next_cursor,omitempty"`
 }
 
@@ -177,11 +212,18 @@ func buildMux(h Handler) http.Handler {
 	mux.HandleFunc("GET /v1/proofs/{record_id}", h.getProof)
 	mux.HandleFunc("GET /v1/roots", h.listRoots)
 	mux.HandleFunc("GET /v1/roots/latest", h.latestRoot)
+	mux.HandleFunc("GET /v1/batches", h.listRoots)
+	mux.HandleFunc("GET /v1/batches/{batch_id}", h.getBatch)
+	mux.HandleFunc("GET /v1/batches/{batch_id}/tree/leaves", h.listBatchTreeLeaves)
+	mux.HandleFunc("GET /v1/batches/{batch_id}/tree/nodes", h.listBatchTreeNodes)
 	if h.Global != nil {
 		mux.HandleFunc("GET /v1/sth", h.listSTHs)
 		mux.HandleFunc("GET /v1/sth/latest", h.latestSTH)
 		mux.HandleFunc("GET /v1/sth/{tree_size}", h.getSTH)
 		mux.HandleFunc("GET /v1/global-log/leaves", h.listGlobalLeaves)
+		mux.HandleFunc("GET /v1/global-log/tree", h.getGlobalTree)
+		mux.HandleFunc("GET /v1/global-log/tree/nodes", h.listGlobalTreeNodes)
+		mux.HandleFunc("GET /v1/global-log/tree/leaves", h.listGlobalLeaves)
 		mux.HandleFunc("GET /v1/global-log/inclusion/{batch_id}", h.getGlobalInclusion)
 		mux.HandleFunc("GET /v1/global-log/consistency", h.getGlobalConsistency)
 	}
@@ -357,6 +399,110 @@ func (h Handler) listRoots(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, rootsResponse{Roots: roots, Limit: opts.Limit, Direction: opts.Direction, NextCursor: next})
 }
 
+func (h Handler) getBatch(w http.ResponseWriter, r *http.Request) {
+	if h.Batch == nil {
+		writeError(w, trusterr.New(trusterr.CodeFailedPrecondition, "batch service is not configured"))
+		return
+	}
+	batchID := strings.TrimSpace(r.PathValue("batch_id"))
+	if batchID == "" {
+		writeError(w, trusterr.New(trusterr.CodeInvalidArgument, "batch_id is required"))
+		return
+	}
+	manifest, err := h.Batch.Manifest(r.Context(), batchID)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, batchResponse{
+		Root: model.BatchRoot{
+			SchemaVersion: model.SchemaBatchRoot,
+			BatchID:       manifest.BatchID,
+			NodeID:        manifest.NodeID,
+			LogID:         manifest.LogID,
+			BatchRoot:     append([]byte(nil), manifest.BatchRoot...),
+			TreeSize:      manifest.TreeSize,
+			ClosedAtUnixN: manifest.ClosedAtUnixN,
+		},
+		Manifest:    manifest,
+		RecordCount: len(manifest.RecordIDs),
+	})
+}
+
+func (h Handler) listBatchTreeLeaves(w http.ResponseWriter, r *http.Request) {
+	if h.Batch == nil {
+		writeError(w, trusterr.New(trusterr.CodeFailedPrecondition, "batch service is not configured"))
+		return
+	}
+	opts, err := parseBatchTreeLeafListOptions(r, r.PathValue("batch_id"))
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	leaves, err := h.Batch.BatchTreeLeaves(r.Context(), opts)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if len(leaves) == 0 && !opts.HasAfter {
+		if err := h.requireBatchTreeIndex(r.Context(), opts.BatchID); err != nil {
+			writeError(w, err)
+			return
+		}
+	}
+	next := ""
+	if len(leaves) == opts.Limit {
+		next = encodeUint64Cursor(leaves[len(leaves)-1].LeafIndex)
+	}
+	writeJSON(w, http.StatusOK, batchLeavesResponse{Leaves: leaves, Limit: opts.Limit, NextCursor: next})
+}
+
+func (h Handler) listBatchTreeNodes(w http.ResponseWriter, r *http.Request) {
+	if h.Batch == nil {
+		writeError(w, trusterr.New(trusterr.CodeFailedPrecondition, "batch service is not configured"))
+		return
+	}
+	opts, err := parseBatchTreeNodeListOptions(r, r.PathValue("batch_id"))
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	nodes, err := h.Batch.BatchTreeNodes(r.Context(), opts)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if len(nodes) == 0 && !opts.HasAfter {
+		if err := h.requireBatchTreeIndex(r.Context(), opts.BatchID); err != nil {
+			writeError(w, err)
+			return
+		}
+	}
+	next := ""
+	if len(nodes) == opts.Limit {
+		next = encodeUint64Cursor(nodes[len(nodes)-1].StartIndex)
+	}
+	writeJSON(w, http.StatusOK, batchNodesResponse{Nodes: nodes, Limit: opts.Limit, NextCursor: next})
+}
+
+func (h Handler) requireBatchTreeIndex(ctx context.Context, batchID string) error {
+	probe, err := h.Batch.BatchTreeLeaves(ctx, model.BatchTreeLeafListOptions{BatchID: batchID, Limit: 1})
+	if err != nil {
+		return err
+	}
+	if len(probe) > 0 {
+		return nil
+	}
+	manifest, err := h.Batch.Manifest(ctx, batchID)
+	if err != nil {
+		return err
+	}
+	if len(manifest.RecordIDs) > 0 || manifest.TreeSize > 0 {
+		return trusterr.New(trusterr.CodeFailedPrecondition, "batch tree index is not available for this batch")
+	}
+	return nil
+}
+
 func parseRecordListOptions(r *http.Request) (model.RecordListOptions, error) {
 	limit := 100
 	if raw := r.URL.Query().Get("limit"); raw != "" {
@@ -511,6 +657,109 @@ func parseGlobalLeafListOptions(r *http.Request) (model.GlobalLeafListOptions, e
 	return opts, nil
 }
 
+func parseBatchTreeLeafListOptions(r *http.Request, batchID string) (model.BatchTreeLeafListOptions, error) {
+	limit, err := parseLimitQuery(r, 100, 1000)
+	if err != nil {
+		return model.BatchTreeLeafListOptions{}, err
+	}
+	opts := model.BatchTreeLeafListOptions{
+		BatchID: strings.TrimSpace(batchID),
+		Limit:   limit,
+	}
+	if opts.BatchID == "" {
+		return model.BatchTreeLeafListOptions{}, trusterr.New(trusterr.CodeInvalidArgument, "batch_id is required")
+	}
+	if raw := r.URL.Query().Get("cursor"); raw != "" {
+		cursor, err := decodeUint64Cursor(raw)
+		if err != nil {
+			return model.BatchTreeLeafListOptions{}, err
+		}
+		opts.AfterLeafIndex = cursor.Value
+		opts.HasAfter = true
+	}
+	return opts, nil
+}
+
+func parseBatchTreeNodeListOptions(r *http.Request, batchID string) (model.BatchTreeNodeListOptions, error) {
+	limit, err := parseLimitQuery(r, 100, 1000)
+	if err != nil {
+		return model.BatchTreeNodeListOptions{}, err
+	}
+	level, err := parseUint64Query(r, "level", 0)
+	if err != nil {
+		return model.BatchTreeNodeListOptions{}, err
+	}
+	start, err := parseUint64Query(r, "start", 0)
+	if err != nil {
+		return model.BatchTreeNodeListOptions{}, err
+	}
+	opts := model.BatchTreeNodeListOptions{
+		BatchID:    strings.TrimSpace(batchID),
+		Level:      level,
+		StartIndex: start,
+		Limit:      limit,
+	}
+	if opts.BatchID == "" {
+		return model.BatchTreeNodeListOptions{}, trusterr.New(trusterr.CodeInvalidArgument, "batch_id is required")
+	}
+	if raw := r.URL.Query().Get("cursor"); raw != "" {
+		cursor, err := decodeUint64Cursor(raw)
+		if err != nil {
+			return model.BatchTreeNodeListOptions{}, err
+		}
+		opts.AfterStartIndex = cursor.Value
+		opts.HasAfter = true
+	}
+	return opts, nil
+}
+
+func parseGlobalNodeListOptions(r *http.Request) (afterLevel, afterStart uint64, limit int, err error) {
+	limit, err = parseLimitQuery(r, 100, 1000)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	afterLevel, afterStart = ^uint64(0), ^uint64(0)
+	if raw := r.URL.Query().Get("cursor"); raw != "" {
+		cursor, err := decodeGlobalNodeCursor(raw)
+		if err != nil {
+			return 0, 0, 0, err
+		}
+		return cursor.Level, cursor.StartIndex, limit, nil
+	}
+	if raw := r.URL.Query().Get("level"); raw != "" {
+		afterLevel, err = strconv.ParseUint(raw, 10, 64)
+		if err != nil {
+			return 0, 0, 0, trusterr.New(trusterr.CodeInvalidArgument, "level must be a non-negative integer")
+		}
+		afterStart = ^uint64(0)
+	}
+	return afterLevel, afterStart, limit, nil
+}
+
+func parseLimitQuery(r *http.Request, fallback, max int) (int, error) {
+	limit := fallback
+	if raw := r.URL.Query().Get("limit"); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed <= 0 || parsed > max {
+			return 0, trusterr.New(trusterr.CodeInvalidArgument, fmt.Sprintf("limit must be between 1 and %d", max))
+		}
+		limit = parsed
+	}
+	return limit, nil
+}
+
+func parseUint64Query(r *http.Request, name string, fallback uint64) (uint64, error) {
+	raw := strings.TrimSpace(r.URL.Query().Get(name))
+	if raw == "" {
+		return fallback, nil
+	}
+	value, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return 0, trusterr.New(trusterr.CodeInvalidArgument, name+" must be a non-negative integer")
+	}
+	return value, nil
+}
+
 func parseAnchorListOptions(r *http.Request) (model.AnchorListOptions, error) {
 	limit := 100
 	if raw := r.URL.Query().Get("limit"); raw != "" {
@@ -641,6 +890,11 @@ type uint64Cursor struct {
 	Value uint64 `json:"v"`
 }
 
+type globalNodeCursor struct {
+	Level      uint64 `json:"l"`
+	StartIndex uint64 `json:"s"`
+}
+
 func encodeUint64Cursor(value uint64) string {
 	data, err := json.Marshal(uint64Cursor{Value: value})
 	if err != nil {
@@ -657,6 +911,26 @@ func decodeUint64Cursor(raw string) (uint64Cursor, error) {
 	var cursor uint64Cursor
 	if err := json.Unmarshal(data, &cursor); err != nil {
 		return uint64Cursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
+	}
+	return cursor, nil
+}
+
+func encodeGlobalNodeCursor(level, startIndex uint64) string {
+	data, err := json.Marshal(globalNodeCursor{Level: level, StartIndex: startIndex})
+	if err != nil {
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(data)
+}
+
+func decodeGlobalNodeCursor(raw string) (globalNodeCursor, error) {
+	data, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return globalNodeCursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
+	}
+	var cursor globalNodeCursor
+	if err := json.Unmarshal(data, &cursor); err != nil {
+		return globalNodeCursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
 	}
 	return cursor, nil
 }
@@ -785,6 +1059,55 @@ func (h Handler) listGlobalLeaves(w http.ResponseWriter, r *http.Request) {
 		Direction:  opts.Direction,
 		NextCursor: next,
 	})
+}
+
+func (h Handler) getGlobalTree(w http.ResponseWriter, r *http.Request) {
+	if h.Global == nil {
+		writeError(w, trusterr.New(trusterr.CodeFailedPrecondition, "global log service is not configured"))
+		return
+	}
+	state, found, err := h.Global.State(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if !found {
+		writeJSON(w, http.StatusOK, globalTreeResponse{OK: false})
+		return
+	}
+	sth, sthFound, err := h.Global.LatestSTH(r.Context())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	resp := globalTreeResponse{State: state, OK: true}
+	if sthFound {
+		resp.STH = &sth
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+func (h Handler) listGlobalTreeNodes(w http.ResponseWriter, r *http.Request) {
+	if h.Global == nil {
+		writeError(w, trusterr.New(trusterr.CodeFailedPrecondition, "global log service is not configured"))
+		return
+	}
+	afterLevel, afterStart, limit, err := parseGlobalNodeListOptions(r)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	nodes, err := h.Global.ListNodesAfter(r.Context(), afterLevel, afterStart, limit)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	next := ""
+	if len(nodes) == limit {
+		last := nodes[len(nodes)-1]
+		next = encodeGlobalNodeCursor(last.Level, last.StartIndex)
+	}
+	writeJSON(w, http.StatusOK, globalNodesResponse{Nodes: nodes, Limit: limit, NextCursor: next})
 }
 
 func (h Handler) getGlobalConsistency(w http.ResponseWriter, r *http.Request) {

--- a/internal/httpapi/handler.go
+++ b/internal/httpapi/handler.go
@@ -61,6 +61,7 @@ type GlobalLogService interface {
 	ListSTHs(context.Context, model.TreeHeadListOptions) ([]model.SignedTreeHead, error)
 	ListLeaves(context.Context, model.GlobalLeafListOptions) ([]model.GlobalLogLeaf, error)
 	State(context.Context) (model.GlobalLogState, bool, error)
+	Node(context.Context, uint64, uint64) (model.GlobalLogNode, bool, error)
 	ListNodesAfter(context.Context, uint64, uint64, int) ([]model.GlobalLogNode, error)
 	InclusionProof(context.Context, string, uint64) (model.GlobalLogProof, error)
 	ConsistencyProof(context.Context, uint64, uint64) (model.GlobalConsistencyProof, error)
@@ -1090,6 +1091,29 @@ func (h Handler) getGlobalTree(w http.ResponseWriter, r *http.Request) {
 func (h Handler) listGlobalTreeNodes(w http.ResponseWriter, r *http.Request) {
 	if h.Global == nil {
 		writeError(w, trusterr.New(trusterr.CodeFailedPrecondition, "global log service is not configured"))
+		return
+	}
+	if strings.TrimSpace(r.URL.Query().Get("start")) != "" {
+		level, err := parseUint64Query(r, "level", 0)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		start, err := parseUint64Query(r, "start", 0)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		node, ok, err := h.Global.Node(r.Context(), level, start)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		nodes := []model.GlobalLogNode(nil)
+		if ok {
+			nodes = append(nodes, node)
+		}
+		writeJSON(w, http.StatusOK, globalNodesResponse{Nodes: nodes, Limit: 1})
 		return
 	}
 	afterLevel, afterStart, limit, err := parseGlobalNodeListOptions(r)

--- a/internal/httpapi/handler_test.go
+++ b/internal/httpapi/handler_test.go
@@ -389,6 +389,126 @@ func TestGlobalAndAnchorListEndpoints(t *testing.T) {
 	}
 }
 
+func TestBatchTreeEndpoints(t *testing.T) {
+	t.Parallel()
+
+	handler := New(nil, nil, &fakeBatchService{
+		roots: []model.BatchRoot{{SchemaVersion: model.SchemaBatchRoot, BatchID: "batch-a", TreeSize: 2, BatchRoot: []byte{9}, ClosedAtUnixN: 100}},
+		manifests: map[string]model.BatchManifest{
+			"batch-a": {SchemaVersion: model.SchemaBatchManifest, BatchID: "batch-a", State: model.BatchStateCommitted, TreeSize: 2, BatchRoot: []byte{9}, RecordIDs: []string{"rec-a", "rec-b"}, ClosedAtUnixN: 100},
+		},
+		treeLeaves: []model.BatchTreeLeaf{
+			{SchemaVersion: model.SchemaBatchTreeLeaf, BatchID: "batch-a", RecordID: "rec-a", LeafIndex: 0, LeafHash: []byte{1}},
+			{SchemaVersion: model.SchemaBatchTreeLeaf, BatchID: "batch-a", RecordID: "rec-b", LeafIndex: 1, LeafHash: []byte{2}},
+		},
+		treeNodes: []model.BatchTreeNode{
+			{SchemaVersion: model.SchemaBatchTreeNode, BatchID: "batch-a", Level: 0, StartIndex: 0, Width: 1, Hash: []byte{1}},
+			{SchemaVersion: model.SchemaBatchTreeNode, BatchID: "batch-a", Level: 0, StartIndex: 1, Width: 1, Hash: []byte{2}},
+			{SchemaVersion: model.SchemaBatchTreeNode, BatchID: "batch-a", Level: 1, StartIndex: 0, Width: 2, Hash: []byte{9}},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/batches/batch-a", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("batch detail status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var detail batchResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode batch detail: %v", err)
+	}
+	if detail.RecordCount != 2 || detail.Root.BatchID != "batch-a" {
+		t.Fatalf("batch detail = %+v", detail)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/v1/batches/batch-a/tree/leaves?limit=1", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("batch leaves status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var leaves batchLeavesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &leaves); err != nil {
+		t.Fatalf("decode batch leaves: %v", err)
+	}
+	if len(leaves.Leaves) != 1 || leaves.Leaves[0].RecordID != "rec-a" || leaves.NextCursor == "" {
+		t.Fatalf("batch leaves = %+v", leaves)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/v1/batches/batch-a/tree/nodes?level=0&limit=2", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("batch nodes status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var nodes batchNodesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &nodes); err != nil {
+		t.Fatalf("decode batch nodes: %v", err)
+	}
+	if len(nodes.Nodes) != 2 || nodes.Nodes[0].StartIndex != 0 || nodes.NextCursor == "" {
+		t.Fatalf("batch nodes = %+v", nodes)
+	}
+}
+
+func TestBatchTreeEndpointReportsMissingIndex(t *testing.T) {
+	t.Parallel()
+
+	handler := New(nil, nil, &fakeBatchService{
+		manifests: map[string]model.BatchManifest{
+			"old-batch": {SchemaVersion: model.SchemaBatchManifest, BatchID: "old-batch", State: model.BatchStateCommitted, TreeSize: 2, RecordIDs: []string{"rec-a", "rec-b"}},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/batches/old-batch/tree/leaves?limit=1", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusPreconditionFailed {
+		t.Fatalf("batch leaves status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGlobalTreeEndpoints(t *testing.T) {
+	t.Parallel()
+
+	handler := NewWithGlobalAndAnchors(nil, nil, &fakeBatchService{}, fakeGlobalService{
+		sths:  []model.SignedTreeHead{{SchemaVersion: model.SchemaSignedTreeHead, TreeSize: 2, RootHash: []byte{9}}},
+		state: model.GlobalLogState{SchemaVersion: model.SchemaGlobalLogState, TreeSize: 2, RootHash: []byte{9}},
+		nodes: []model.GlobalLogNode{
+			{SchemaVersion: model.SchemaGlobalLogNode, Level: 0, StartIndex: 0, Width: 1, Hash: []byte{1}},
+			{SchemaVersion: model.SchemaGlobalLogNode, Level: 0, StartIndex: 1, Width: 1, Hash: []byte{2}},
+		},
+	}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/global-log/tree", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("global tree status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var tree globalTreeResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &tree); err != nil {
+		t.Fatalf("decode global tree: %v", err)
+	}
+	if !tree.OK || tree.State.TreeSize != 2 || tree.STH == nil {
+		t.Fatalf("global tree = %+v", tree)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/v1/global-log/tree/nodes?limit=1", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("global nodes status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var nodes globalNodesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &nodes); err != nil {
+		t.Fatalf("decode global nodes: %v", err)
+	}
+	if len(nodes.Nodes) != 1 || nodes.NextCursor == "" {
+		t.Fatalf("global nodes = %+v", nodes)
+	}
+}
+
 func TestGlobalRoutesAreNotRegisteredWithoutGlobalService(t *testing.T) {
 	t.Parallel()
 
@@ -397,6 +517,8 @@ func TestGlobalRoutesAreNotRegisteredWithoutGlobalService(t *testing.T) {
 		"/v1/sth/latest",
 		"/v1/sth",
 		"/v1/global-log/leaves",
+		"/v1/global-log/tree",
+		"/v1/global-log/tree/nodes",
 		"/v1/global-log/inclusion/batch-1",
 		"/v1/global-log/consistency?from=1&to=2",
 	} {
@@ -418,6 +540,8 @@ func TestGlobalRoutesAreNotRegisteredWithTypedNilGlobalService(t *testing.T) {
 		"/v1/sth/latest",
 		"/v1/sth",
 		"/v1/global-log/leaves",
+		"/v1/global-log/tree",
+		"/v1/global-log/tree/nodes",
 		"/v1/global-log/inclusion/batch-1",
 		"/v1/global-log/consistency?from=1&to=2",
 	} {
@@ -440,11 +564,14 @@ func (f processorFunc) Submit(ctx context.Context, signed model.SignedClaim) (mo
 }
 
 type fakeBatchService struct {
-	mu       sync.Mutex
-	enqueued string
-	proof    model.ProofBundle
-	roots    []model.BatchRoot
-	records  []model.RecordIndex
+	mu         sync.Mutex
+	enqueued   string
+	proof      model.ProofBundle
+	roots      []model.BatchRoot
+	records    []model.RecordIndex
+	manifests  map[string]model.BatchManifest
+	treeLeaves []model.BatchTreeLeaf
+	treeNodes  []model.BatchTreeNode
 }
 
 func (f *fakeBatchService) Enqueue(ctx context.Context, signed model.SignedClaim, record model.ServerRecord, accepted model.AcceptedReceipt) error {
@@ -544,6 +671,63 @@ func (f *fakeBatchService) LatestRoot(ctx context.Context) (model.BatchRoot, err
 	return f.roots[0], nil
 }
 
+func (f *fakeBatchService) Manifest(ctx context.Context, batchID string) (model.BatchManifest, error) {
+	if f.manifests != nil {
+		if manifest, ok := f.manifests[batchID]; ok {
+			return manifest, nil
+		}
+	}
+	for _, root := range f.roots {
+		if root.BatchID == batchID {
+			return model.BatchManifest{
+				SchemaVersion: model.SchemaBatchManifest,
+				BatchID:       root.BatchID,
+				NodeID:        root.NodeID,
+				LogID:         root.LogID,
+				State:         model.BatchStateCommitted,
+				TreeSize:      root.TreeSize,
+				BatchRoot:     append([]byte(nil), root.BatchRoot...),
+				ClosedAtUnixN: root.ClosedAtUnixN,
+			}, nil
+		}
+	}
+	return model.BatchManifest{}, trusterr.New(trusterr.CodeNotFound, "batch manifest not found")
+}
+
+func (f *fakeBatchService) BatchTreeLeaves(ctx context.Context, opts model.BatchTreeLeafListOptions) ([]model.BatchTreeLeaf, error) {
+	out := make([]model.BatchTreeLeaf, 0, opts.Limit)
+	for _, leaf := range f.treeLeaves {
+		if leaf.BatchID != opts.BatchID {
+			continue
+		}
+		if opts.HasAfter && leaf.LeafIndex <= opts.AfterLeafIndex {
+			continue
+		}
+		out = append(out, leaf)
+		if len(out) >= opts.Limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeBatchService) BatchTreeNodes(ctx context.Context, opts model.BatchTreeNodeListOptions) ([]model.BatchTreeNode, error) {
+	out := make([]model.BatchTreeNode, 0, opts.Limit)
+	for _, node := range f.treeNodes {
+		if node.BatchID != opts.BatchID || node.Level != opts.Level || node.StartIndex < opts.StartIndex {
+			continue
+		}
+		if opts.HasAfter && node.StartIndex <= opts.AfterStartIndex {
+			continue
+		}
+		out = append(out, node)
+		if len(out) >= opts.Limit {
+			break
+		}
+	}
+	return out, nil
+}
+
 func (f *fakeBatchService) enqueuedRecordID() string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -553,6 +737,8 @@ func (f *fakeBatchService) enqueuedRecordID() string {
 type fakeGlobalService struct {
 	sths   []model.SignedTreeHead
 	leaves []model.GlobalLogLeaf
+	state  model.GlobalLogState
+	nodes  []model.GlobalLogNode
 }
 
 func (f fakeGlobalService) LatestSTH(context.Context) (model.SignedTreeHead, bool, error) {
@@ -611,6 +797,28 @@ func (f fakeGlobalService) ListLeaves(_ context.Context, opts model.GlobalLeafLi
 		}
 		out = append(out, leaf)
 		if len(out) >= opts.Limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (f fakeGlobalService) State(context.Context) (model.GlobalLogState, bool, error) {
+	if f.state.TreeSize == 0 && len(f.state.RootHash) == 0 {
+		return model.GlobalLogState{}, false, nil
+	}
+	return f.state, true, nil
+}
+
+func (f fakeGlobalService) ListNodesAfter(_ context.Context, afterLevel, afterStartIndex uint64, limit int) ([]model.GlobalLogNode, error) {
+	out := make([]model.GlobalLogNode, 0, limit)
+	hasCursor := afterLevel != ^uint64(0) || afterStartIndex != ^uint64(0)
+	for _, node := range f.nodes {
+		if hasCursor && (node.Level < afterLevel || node.Level == afterLevel && node.StartIndex <= afterStartIndex) {
+			continue
+		}
+		out = append(out, node)
+		if len(out) >= limit {
 			break
 		}
 	}

--- a/internal/httpapi/handler_test.go
+++ b/internal/httpapi/handler_test.go
@@ -507,6 +507,20 @@ func TestGlobalTreeEndpoints(t *testing.T) {
 	if len(nodes.Nodes) != 1 || nodes.NextCursor == "" {
 		t.Fatalf("global nodes = %+v", nodes)
 	}
+
+	req = httptest.NewRequest(http.MethodGet, "/v1/global-log/tree/nodes?level=0&start=1", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("global exact node status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var exact globalNodesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &exact); err != nil {
+		t.Fatalf("decode global exact node: %v", err)
+	}
+	if len(exact.Nodes) != 1 || exact.Nodes[0].StartIndex != 1 || exact.NextCursor != "" {
+		t.Fatalf("global exact node = %+v", exact)
+	}
 }
 
 func TestGlobalRoutesAreNotRegisteredWithoutGlobalService(t *testing.T) {
@@ -808,6 +822,15 @@ func (f fakeGlobalService) State(context.Context) (model.GlobalLogState, bool, e
 		return model.GlobalLogState{}, false, nil
 	}
 	return f.state, true, nil
+}
+
+func (f fakeGlobalService) Node(_ context.Context, level, startIndex uint64) (model.GlobalLogNode, bool, error) {
+	for _, node := range f.nodes {
+		if node.Level == level && node.StartIndex == startIndex {
+			return node, true, nil
+		}
+	}
+	return model.GlobalLogNode{}, false, nil
 }
 
 func (f fakeGlobalService) ListNodesAfter(_ context.Context, afterLevel, afterStartIndex uint64, limit int) ([]model.GlobalLogNode, error) {

--- a/internal/merkle/merkle.go
+++ b/internal/merkle/merkle.go
@@ -16,6 +16,18 @@ type Tree struct {
 	nodes      map[nodeRange][sha256.Size]byte
 }
 
+type Leaf struct {
+	Index uint64
+	Hash  []byte
+}
+
+type Node struct {
+	Level      uint64
+	StartIndex uint64
+	Width      uint64
+	Hash       []byte
+}
+
 func Build(records []model.ServerRecord) (Tree, error) {
 	if len(records) == 0 {
 		return Tree{}, errors.New("merkle: cannot build empty tree")
@@ -94,6 +106,30 @@ func (t Tree) LeafHash(index int) ([]byte, error) {
 		return nil, fmt.Errorf("merkle: leaf index out of range: %d", index)
 	}
 	return cloneHash(t.leafHashes[index]), nil
+}
+
+func (t Tree) Leaves() []Leaf {
+	out := make([]Leaf, len(t.leafHashes))
+	for i := range t.leafHashes {
+		out[i] = Leaf{
+			Index: uint64(i),
+			Hash:  cloneHash(t.leafHashes[i]),
+		}
+	}
+	return out
+}
+
+func (t Tree) Nodes() []Node {
+	out := make([]Node, 0, len(t.nodes))
+	for r, hash := range t.nodes {
+		out = append(out, Node{
+			Level:      rangeLevel(r.size),
+			StartIndex: uint64(r.start),
+			Width:      uint64(r.size),
+			Hash:       cloneHash(hash),
+		})
+	}
+	return out
 }
 
 func (t Tree) Proof(index int) ([][]byte, error) {
@@ -265,4 +301,17 @@ func largestPowerOfTwoLessThan(n int) int {
 		k <<= 1
 	}
 	return k
+}
+
+func rangeLevel(size int) uint64 {
+	if size <= 1 {
+		return 0
+	}
+	level := uint64(0)
+	width := 1
+	for width < size {
+		width <<= 1
+		level++
+	}
+	return level
 }

--- a/internal/merkle/merkle_test.go
+++ b/internal/merkle/merkle_test.go
@@ -105,6 +105,41 @@ func TestVerifyRejectsWrongRoot(t *testing.T) {
 	}
 }
 
+func TestTreeLeavesAndNodesExposeStableSnapshot(t *testing.T) {
+	t.Parallel()
+
+	records := []model.ServerRecord{record("a"), record("b"), record("c")}
+	tree, err := Build(records)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	leaves := tree.Leaves()
+	if len(leaves) != 3 {
+		t.Fatalf("Leaves() len = %d, want 3", len(leaves))
+	}
+	for i := range leaves {
+		if leaves[i].Index != uint64(i) || len(leaves[i].Hash) != 32 {
+			t.Fatalf("leaf %d = %+v", i, leaves[i])
+		}
+	}
+	nodes := tree.Nodes()
+	if len(nodes) != 5 {
+		t.Fatalf("Nodes() len = %d, want 5", len(nodes))
+	}
+	var rootNodeFound bool
+	for _, node := range nodes {
+		if node.StartIndex == 0 && node.Width == 3 {
+			rootNodeFound = true
+			if node.Level != 2 || !bytes.Equal(node.Hash, tree.Root()) {
+				t.Fatalf("root node = %+v", node)
+			}
+		}
+	}
+	if !rootNodeFound {
+		t.Fatalf("Nodes() missing root node: %+v", nodes)
+	}
+}
+
 func TestBuildRejectsEmptyRecords(t *testing.T) {
 	t.Parallel()
 

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -11,6 +11,8 @@ const (
 	SchemaRecordIndex       = "trustdb.record-index.v1"
 	SchemaBatchRoot         = "trustdb.batch-root.v1"
 	SchemaBatchManifest     = "trustdb.batch-manifest.v1"
+	SchemaBatchTreeLeaf     = "trustdb.batch-tree-leaf.v1"
+	SchemaBatchTreeNode     = "trustdb.batch-tree-node.v1"
 	SchemaWALCheckpoint     = "trustdb.wal-checkpoint.v1"
 	SchemaKeyEvent          = "trustdb.key-event.v1"
 	SchemaGlobalLogLeaf     = "trustdb.global-log-leaf.v1"
@@ -237,6 +239,22 @@ type RootListOptions struct {
 	AfterBatchID       string
 }
 
+type BatchTreeLeafListOptions struct {
+	BatchID        string
+	Limit          int
+	AfterLeafIndex uint64
+	HasAfter       bool
+}
+
+type BatchTreeNodeListOptions struct {
+	BatchID         string
+	Level           uint64
+	StartIndex      uint64
+	Limit           int
+	AfterStartIndex uint64
+	HasAfter        bool
+}
+
 type TreeHeadListOptions struct {
 	Limit         int
 	Direction     string
@@ -348,6 +366,31 @@ type BatchManifest struct {
 	ClosedAtUnixN    int64    `cbor:"closed_at_unix_nano" json:"closed_at_unix_nano"`
 	PreparedAtUnixN  int64    `cbor:"prepared_at_unix_nano" json:"prepared_at_unix_nano"`
 	CommittedAtUnixN int64    `cbor:"committed_at_unix_nano,omitempty" json:"committed_at_unix_nano,omitempty"`
+}
+
+// BatchTreeLeaf is a lightweight projection for browsing a batch Merkle tree.
+// It intentionally stores only the record binding and leaf hash so API callers
+// can page through huge batches without loading full proof bundles.
+type BatchTreeLeaf struct {
+	SchemaVersion  string `cbor:"schema_version" json:"schema_version"`
+	BatchID        string `cbor:"batch_id" json:"batch_id"`
+	RecordID       string `cbor:"record_id" json:"record_id"`
+	LeafIndex      uint64 `cbor:"leaf_index" json:"leaf_index"`
+	LeafHash       []byte `cbor:"leaf_hash" json:"leaf_hash"`
+	CreatedAtUnixN int64  `cbor:"created_at_unix_nano" json:"created_at_unix_nano"`
+}
+
+// BatchTreeNode stores complete Merkle subtrees for one batch. The pair
+// (level,start_index) is ordered for range scans; width is usually 2^level
+// except for right-edge RFC6962 subtrees in non-power-of-two batches.
+type BatchTreeNode struct {
+	SchemaVersion  string `cbor:"schema_version" json:"schema_version"`
+	BatchID        string `cbor:"batch_id" json:"batch_id"`
+	Level          uint64 `cbor:"level" json:"level"`
+	StartIndex     uint64 `cbor:"start_index" json:"start_index"`
+	Width          uint64 `cbor:"width" json:"width"`
+	Hash           []byte `cbor:"hash" json:"hash"`
+	CreatedAtUnixN int64  `cbor:"created_at_unix_nano" json:"created_at_unix_nano"`
 }
 
 // GlobalLogLeaf is the append-only global transparency log item for one

--- a/internal/proofstore/local.go
+++ b/internal/proofstore/local.go
@@ -323,6 +323,157 @@ func (s LocalStore) LatestRoot(ctx context.Context) (model.BatchRoot, error) {
 	return roots[0], nil
 }
 
+func (s LocalStore) PutBatchTreeArtifacts(ctx context.Context, leaves []model.BatchTreeLeaf, nodes []model.BatchTreeNode) error {
+	if err := ctx.Err(); err != nil {
+		return trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore put batch tree artifacts canceled", err)
+	}
+	if len(leaves) == 0 {
+		return trusterr.New(trusterr.CodeInvalidArgument, "batch tree artifacts require at least one leaf")
+	}
+	batchID := leaves[0].BatchID
+	if batchID == "" {
+		return trusterr.New(trusterr.CodeInvalidArgument, "batch tree artifact batch_id is required")
+	}
+	now := time.Now().UTC().UnixNano()
+	for i := range leaves {
+		if err := ctx.Err(); err != nil {
+			return trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore put batch tree artifacts canceled", err)
+		}
+		leaf := leaves[i]
+		if leaf.BatchID != batchID {
+			return trusterr.New(trusterr.CodeInvalidArgument, "batch tree leaves must share batch_id")
+		}
+		if leaf.SchemaVersion == "" {
+			leaf.SchemaVersion = model.SchemaBatchTreeLeaf
+		}
+		if leaf.CreatedAtUnixN == 0 {
+			leaf.CreatedAtUnixN = now
+		}
+		if err := writeCBORAtomic(s.batchTreeLeafPath(leaf.BatchID, leaf.LeafIndex), leaf); err != nil {
+			return trusterr.Wrap(trusterr.CodeDataLoss, "write batch tree leaf", err)
+		}
+	}
+	for i := range nodes {
+		if err := ctx.Err(); err != nil {
+			return trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore put batch tree artifacts canceled", err)
+		}
+		node := nodes[i]
+		if node.BatchID != batchID {
+			return trusterr.New(trusterr.CodeInvalidArgument, "batch tree nodes must share batch_id")
+		}
+		if node.Width == 0 {
+			return trusterr.New(trusterr.CodeInvalidArgument, "batch tree node width is required")
+		}
+		if node.SchemaVersion == "" {
+			node.SchemaVersion = model.SchemaBatchTreeNode
+		}
+		if node.CreatedAtUnixN == 0 {
+			node.CreatedAtUnixN = now
+		}
+		if err := writeCBORAtomic(s.batchTreeNodePath(node.BatchID, node.Level, node.StartIndex), node); err != nil {
+			return trusterr.Wrap(trusterr.CodeDataLoss, "write batch tree node", err)
+		}
+	}
+	return nil
+}
+
+func (s LocalStore) ListBatchTreeLeaves(ctx context.Context, opts model.BatchTreeLeafListOptions) ([]model.BatchTreeLeaf, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list batch tree leaves canceled", err)
+	}
+	if opts.BatchID == "" {
+		return nil, trusterr.New(trusterr.CodeInvalidArgument, "batch_id is required")
+	}
+	limit := normaliseRecordLimit(opts.Limit)
+	entries, err := os.ReadDir(s.batchTreeLeafDir(opts.BatchID))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "read batch tree leaf directory", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".tdbtleaf") {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	leaves := make([]model.BatchTreeLeaf, 0, limit)
+	for _, name := range names {
+		if err := ctx.Err(); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list batch tree leaves canceled", err)
+		}
+		data, err := os.ReadFile(filepath.Join(s.batchTreeLeafDir(opts.BatchID), name))
+		if err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "read batch tree leaf", err)
+		}
+		var leaf model.BatchTreeLeaf
+		if err := cborx.UnmarshalLimit(data, &leaf, maxStoredObjectBytes); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "decode batch tree leaf", err)
+		}
+		if opts.HasAfter && leaf.LeafIndex <= opts.AfterLeafIndex {
+			continue
+		}
+		leaves = append(leaves, leaf)
+		if len(leaves) >= limit {
+			break
+		}
+	}
+	return leaves, nil
+}
+
+func (s LocalStore) ListBatchTreeNodes(ctx context.Context, opts model.BatchTreeNodeListOptions) ([]model.BatchTreeNode, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list batch tree nodes canceled", err)
+	}
+	if opts.BatchID == "" {
+		return nil, trusterr.New(trusterr.CodeInvalidArgument, "batch_id is required")
+	}
+	limit := normaliseRecordLimit(opts.Limit)
+	entries, err := os.ReadDir(s.batchTreeNodeLevelDir(opts.BatchID, opts.Level))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "read batch tree node directory", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".tdbtnode") {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	nodes := make([]model.BatchTreeNode, 0, limit)
+	for _, name := range names {
+		if err := ctx.Err(); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list batch tree nodes canceled", err)
+		}
+		data, err := os.ReadFile(filepath.Join(s.batchTreeNodeLevelDir(opts.BatchID, opts.Level), name))
+		if err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "read batch tree node", err)
+		}
+		var node model.BatchTreeNode
+		if err := cborx.UnmarshalLimit(data, &node, maxStoredObjectBytes); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "decode batch tree node", err)
+		}
+		if node.StartIndex < opts.StartIndex {
+			continue
+		}
+		if opts.HasAfter && node.StartIndex <= opts.AfterStartIndex {
+			continue
+		}
+		nodes = append(nodes, node)
+		if len(nodes) >= limit {
+			break
+		}
+	}
+	return nodes, nil
+}
+
 func (s LocalStore) PutManifest(ctx context.Context, manifest model.BatchManifest) error {
 	if err := ctx.Err(); err != nil {
 		return trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore put manifest canceled", err)
@@ -1567,6 +1718,22 @@ func (s LocalStore) globalLeafByBatchPath(batchID string) string {
 
 func (s LocalStore) globalNodePath(level, start uint64) string {
 	return filepath.Join(s.globalNodeDir(), fmt.Sprintf("%020d_%020d.tdgnode", level, start))
+}
+
+func (s LocalStore) batchTreeLeafDir(batchID string) string {
+	return filepath.Join(s.root(), "batch-trees", safeFileName(batchID), "leaves")
+}
+
+func (s LocalStore) batchTreeLeafPath(batchID string, index uint64) string {
+	return filepath.Join(s.batchTreeLeafDir(batchID), fmt.Sprintf("%020d.tdbtleaf", index))
+}
+
+func (s LocalStore) batchTreeNodeLevelDir(batchID string, level uint64) string {
+	return filepath.Join(s.root(), "batch-trees", safeFileName(batchID), "nodes", fmt.Sprintf("%020d", level))
+}
+
+func (s LocalStore) batchTreeNodePath(batchID string, level, start uint64) string {
+	return filepath.Join(s.batchTreeNodeLevelDir(batchID, level), fmt.Sprintf("%020d.tdbtnode", start))
 }
 
 func (s LocalStore) sthPath(treeSize uint64) string {

--- a/internal/proofstore/pebble/store.go
+++ b/internal/proofstore/pebble/store.go
@@ -51,6 +51,8 @@ const (
 	prefixRecordByToken  = "record/by-storage-token/"
 	prefixManifest       = "manifest/"
 	prefixRoot           = "root/"
+	prefixBatchTreeLeaf  = "batch-tree/leaf/"
+	prefixBatchTreeNode  = "batch-tree/node/"
 	prefixGlobalLeaf     = "global/leaf/"
 	prefixGlobalBatch    = "global/leaf-by-batch/"
 	prefixGlobalNode     = "global/node/"
@@ -372,6 +374,14 @@ func rootKey(closedAtUnixN int64, batchID string) []byte {
 	k = append(k, '/')
 	k = append(k, batchID...)
 	return k
+}
+
+func batchTreeLeafKey(batchID string, leafIndex uint64) []byte {
+	return []byte(fmt.Sprintf("%s%s/%0*d", prefixBatchTreeLeaf, batchID, rootSortKeyWidth, leafIndex))
+}
+
+func batchTreeNodeKey(batchID string, level, startIndex uint64) []byte {
+	return []byte(fmt.Sprintf("%s%s/%0*d/%0*d", prefixBatchTreeNode, batchID, rootSortKeyWidth, level, rootSortKeyWidth, startIndex))
 }
 
 func isNotFound(err error) bool {
@@ -1140,6 +1150,184 @@ func (s *Store) LatestRoot(ctx context.Context) (model.BatchRoot, error) {
 		return model.BatchRoot{}, trusterr.New(trusterr.CodeNotFound, "batch root not found")
 	}
 	return roots[0], nil
+}
+
+func (s *Store) PutBatchTreeArtifacts(ctx context.Context, leaves []model.BatchTreeLeaf, nodes []model.BatchTreeNode) error {
+	if err := ctx.Err(); err != nil {
+		return trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore put batch tree artifacts canceled", err)
+	}
+	if len(leaves) == 0 {
+		return trusterr.New(trusterr.CodeInvalidArgument, "batch tree artifacts require at least one leaf")
+	}
+	batchID := leaves[0].BatchID
+	if batchID == "" {
+		return trusterr.New(trusterr.CodeInvalidArgument, "batch tree artifact batch_id is required")
+	}
+	now := time.Now().UTC().UnixNano()
+	for start := 0; start < len(leaves); start += batchArtifactChunkSize {
+		end := start + batchArtifactChunkSize
+		if end > len(leaves) {
+			end = len(leaves)
+		}
+		batch := s.db.NewBatch()
+		for i := start; i < end; i++ {
+			leaf := leaves[i]
+			if leaf.BatchID != batchID {
+				_ = batch.Close()
+				return trusterr.New(trusterr.CodeInvalidArgument, "batch tree leaves must share batch_id")
+			}
+			if leaf.SchemaVersion == "" {
+				leaf.SchemaVersion = model.SchemaBatchTreeLeaf
+			}
+			if leaf.CreatedAtUnixN == 0 {
+				leaf.CreatedAtUnixN = now
+			}
+			data, err := cborx.Marshal(leaf)
+			if err != nil {
+				_ = batch.Close()
+				return err
+			}
+			if err := stageSet(batch, batchTreeLeafKey(leaf.BatchID, leaf.LeafIndex), data); err != nil {
+				_ = batch.Close()
+				return trusterr.Wrap(trusterr.CodeDataLoss, "stage batch tree leaf", err)
+			}
+		}
+		if err := batch.Commit(s.artifactWriteOptions()); err != nil {
+			_ = batch.Close()
+			return trusterr.Wrap(trusterr.CodeDataLoss, "commit batch tree leaves", err)
+		}
+		if err := batch.Close(); err != nil {
+			return trusterr.Wrap(trusterr.CodeDataLoss, "close batch tree leaves", err)
+		}
+	}
+	for start := 0; start < len(nodes); start += batchArtifactChunkSize {
+		end := start + batchArtifactChunkSize
+		if end > len(nodes) {
+			end = len(nodes)
+		}
+		batch := s.db.NewBatch()
+		for i := start; i < end; i++ {
+			node := nodes[i]
+			if node.BatchID != batchID {
+				_ = batch.Close()
+				return trusterr.New(trusterr.CodeInvalidArgument, "batch tree nodes must share batch_id")
+			}
+			if node.Width == 0 {
+				_ = batch.Close()
+				return trusterr.New(trusterr.CodeInvalidArgument, "batch tree node width is required")
+			}
+			if node.SchemaVersion == "" {
+				node.SchemaVersion = model.SchemaBatchTreeNode
+			}
+			if node.CreatedAtUnixN == 0 {
+				node.CreatedAtUnixN = now
+			}
+			data, err := cborx.Marshal(node)
+			if err != nil {
+				_ = batch.Close()
+				return err
+			}
+			if err := stageSet(batch, batchTreeNodeKey(node.BatchID, node.Level, node.StartIndex), data); err != nil {
+				_ = batch.Close()
+				return trusterr.Wrap(trusterr.CodeDataLoss, "stage batch tree node", err)
+			}
+		}
+		if err := batch.Commit(s.artifactWriteOptions()); err != nil {
+			_ = batch.Close()
+			return trusterr.Wrap(trusterr.CodeDataLoss, "commit batch tree nodes", err)
+		}
+		if err := batch.Close(); err != nil {
+			return trusterr.Wrap(trusterr.CodeDataLoss, "close batch tree nodes", err)
+		}
+	}
+	return nil
+}
+
+func (s *Store) ListBatchTreeLeaves(ctx context.Context, opts model.BatchTreeLeafListOptions) ([]model.BatchTreeLeaf, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list batch tree leaves canceled", err)
+	}
+	if opts.BatchID == "" {
+		return nil, trusterr.New(trusterr.CodeInvalidArgument, "batch_id is required")
+	}
+	limit := normaliseRecordLimit(opts.Limit)
+	prefix := fmt.Sprintf("%s%s/", prefixBatchTreeLeaf, opts.BatchID)
+	lower, upper := prefixBounds(prefix)
+	iter, err := s.db.NewIter(&pdb.IterOptions{LowerBound: lower, UpperBound: upper})
+	if err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "open batch tree leaf iterator", err)
+	}
+	defer iter.Close()
+	ok := iter.First()
+	if opts.HasAfter {
+		ok = iter.SeekGE(batchTreeLeafKey(opts.BatchID, opts.AfterLeafIndex))
+	}
+	leaves := make([]model.BatchTreeLeaf, 0, limit)
+	for ; ok; ok = iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list batch tree leaves canceled", err)
+		}
+		if len(leaves) >= limit {
+			break
+		}
+		var leaf model.BatchTreeLeaf
+		if err := cborx.UnmarshalLimit(iter.Value(), &leaf, maxStoredObjectBytes); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "decode batch tree leaf", err)
+		}
+		if opts.HasAfter && leaf.LeafIndex <= opts.AfterLeafIndex {
+			continue
+		}
+		leaves = append(leaves, leaf)
+	}
+	if err := iter.Error(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "iterate batch tree leaves", err)
+	}
+	return leaves, nil
+}
+
+func (s *Store) ListBatchTreeNodes(ctx context.Context, opts model.BatchTreeNodeListOptions) ([]model.BatchTreeNode, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list batch tree nodes canceled", err)
+	}
+	if opts.BatchID == "" {
+		return nil, trusterr.New(trusterr.CodeInvalidArgument, "batch_id is required")
+	}
+	limit := normaliseRecordLimit(opts.Limit)
+	prefix := fmt.Sprintf("%s%s/%0*d/", prefixBatchTreeNode, opts.BatchID, rootSortKeyWidth, opts.Level)
+	lower, upper := prefixBounds(prefix)
+	iter, err := s.db.NewIter(&pdb.IterOptions{LowerBound: lower, UpperBound: upper})
+	if err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "open batch tree node iterator", err)
+	}
+	defer iter.Close()
+	ok := iter.SeekGE(batchTreeNodeKey(opts.BatchID, opts.Level, opts.StartIndex))
+	if opts.HasAfter && opts.AfterStartIndex >= opts.StartIndex {
+		ok = iter.SeekGE(batchTreeNodeKey(opts.BatchID, opts.Level, opts.AfterStartIndex))
+	}
+	nodes := make([]model.BatchTreeNode, 0, limit)
+	for ; ok; ok = iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list batch tree nodes canceled", err)
+		}
+		if len(nodes) >= limit {
+			break
+		}
+		var node model.BatchTreeNode
+		if err := cborx.UnmarshalLimit(iter.Value(), &node, maxStoredObjectBytes); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "decode batch tree node", err)
+		}
+		if node.StartIndex < opts.StartIndex {
+			continue
+		}
+		if opts.HasAfter && node.StartIndex <= opts.AfterStartIndex {
+			continue
+		}
+		nodes = append(nodes, node)
+	}
+	if err := iter.Error(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "iterate batch tree nodes", err)
+	}
+	return nodes, nil
 }
 
 func (s *Store) PutManifest(ctx context.Context, manifest model.BatchManifest) error {

--- a/internal/proofstore/proofstoretest/conformance.go
+++ b/internal/proofstore/proofstoretest/conformance.go
@@ -37,6 +37,7 @@ func RunConformance(t *testing.T, newStore Factory) {
 	t.Run("RootListAcceptsHugeLimit", func(t *testing.T) { testRootListAcceptsHugeLimit(t, newStore) })
 	t.Run("LatestRootSelectsNewest", func(t *testing.T) { testLatestRoot(t, newStore) })
 	t.Run("RootListPagePaginates", func(t *testing.T) { testRootListPagePaginates(t, newStore) })
+	t.Run("BatchTreeArtifactsRoundTrip", func(t *testing.T) { testBatchTreeArtifactsRoundTrip(t, newStore) })
 	t.Run("CheckpointRoundTrip", func(t *testing.T) { testCheckpointRoundTrip(t, newStore) })
 	t.Run("CheckpointMissing", func(t *testing.T) { testCheckpointMissing(t, newStore) })
 	t.Run("ConcurrentPutBundle", func(t *testing.T) { testConcurrentPutBundle(t, newStore) })
@@ -509,6 +510,56 @@ func testRootListPagePaginates(t *testing.T, newStore Factory) {
 	}
 	if len(next) != 1 || next[0].BatchID != "batch-1" {
 		t.Fatalf("next roots page = %+v", next)
+	}
+}
+
+func testBatchTreeArtifactsRoundTrip(t *testing.T, newStore Factory) {
+	t.Parallel()
+	store, cleanup := newStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	leaves := []model.BatchTreeLeaf{
+		{SchemaVersion: model.SchemaBatchTreeLeaf, BatchID: "batch-tree", RecordID: "rec-0", LeafIndex: 0, LeafHash: []byte{1}},
+		{SchemaVersion: model.SchemaBatchTreeLeaf, BatchID: "batch-tree", RecordID: "rec-1", LeafIndex: 1, LeafHash: []byte{2}},
+		{SchemaVersion: model.SchemaBatchTreeLeaf, BatchID: "batch-tree", RecordID: "rec-2", LeafIndex: 2, LeafHash: []byte{3}},
+	}
+	nodes := []model.BatchTreeNode{
+		{SchemaVersion: model.SchemaBatchTreeNode, BatchID: "batch-tree", Level: 0, StartIndex: 0, Width: 1, Hash: []byte{1}},
+		{SchemaVersion: model.SchemaBatchTreeNode, BatchID: "batch-tree", Level: 0, StartIndex: 1, Width: 1, Hash: []byte{2}},
+		{SchemaVersion: model.SchemaBatchTreeNode, BatchID: "batch-tree", Level: 1, StartIndex: 0, Width: 2, Hash: []byte{4}},
+		{SchemaVersion: model.SchemaBatchTreeNode, BatchID: "batch-tree", Level: 2, StartIndex: 0, Width: 3, Hash: []byte{5}},
+	}
+	if err := store.PutBatchTreeArtifacts(ctx, leaves, nodes); err != nil {
+		t.Fatalf("PutBatchTreeArtifacts: %v", err)
+	}
+	firstLeaves, err := store.ListBatchTreeLeaves(ctx, model.BatchTreeLeafListOptions{BatchID: "batch-tree", Limit: 2})
+	if err != nil {
+		t.Fatalf("ListBatchTreeLeaves first: %v", err)
+	}
+	if len(firstLeaves) != 2 || firstLeaves[0].RecordID != "rec-0" || firstLeaves[1].RecordID != "rec-1" {
+		t.Fatalf("first leaves page = %+v", firstLeaves)
+	}
+	nextLeaves, err := store.ListBatchTreeLeaves(ctx, model.BatchTreeLeafListOptions{BatchID: "batch-tree", Limit: 2, AfterLeafIndex: firstLeaves[1].LeafIndex, HasAfter: true})
+	if err != nil {
+		t.Fatalf("ListBatchTreeLeaves next: %v", err)
+	}
+	if len(nextLeaves) != 1 || nextLeaves[0].RecordID != "rec-2" {
+		t.Fatalf("next leaves page = %+v", nextLeaves)
+	}
+	levelZero, err := store.ListBatchTreeNodes(ctx, model.BatchTreeNodeListOptions{BatchID: "batch-tree", Level: 0, Limit: 10})
+	if err != nil {
+		t.Fatalf("ListBatchTreeNodes level0: %v", err)
+	}
+	if len(levelZero) != 2 || levelZero[0].StartIndex != 0 || levelZero[1].StartIndex != 1 {
+		t.Fatalf("level0 nodes = %+v", levelZero)
+	}
+	levelOne, err := store.ListBatchTreeNodes(ctx, model.BatchTreeNodeListOptions{BatchID: "batch-tree", Level: 1, StartIndex: 0, Limit: 1})
+	if err != nil {
+		t.Fatalf("ListBatchTreeNodes level1: %v", err)
+	}
+	if len(levelOne) != 1 || levelOne[0].Width != 2 {
+		t.Fatalf("level1 nodes = %+v", levelOne)
 	}
 }
 

--- a/internal/proofstore/store.go
+++ b/internal/proofstore/store.go
@@ -29,6 +29,9 @@ type Store interface {
 	ListRootsAfter(ctx context.Context, afterClosedAtUnixN int64, limit int) ([]model.BatchRoot, error)
 	ListRootsPage(ctx context.Context, opts model.RootListOptions) ([]model.BatchRoot, error)
 	LatestRoot(ctx context.Context) (model.BatchRoot, error)
+	PutBatchTreeArtifacts(ctx context.Context, leaves []model.BatchTreeLeaf, nodes []model.BatchTreeNode) error
+	ListBatchTreeLeaves(ctx context.Context, opts model.BatchTreeLeafListOptions) ([]model.BatchTreeLeaf, error)
+	ListBatchTreeNodes(ctx context.Context, opts model.BatchTreeNodeListOptions) ([]model.BatchTreeNode, error)
 	PutManifest(ctx context.Context, manifest model.BatchManifest) error
 	GetManifest(ctx context.Context, batchID string) (model.BatchManifest, error)
 	ListManifests(ctx context.Context) ([]model.BatchManifest, error)

--- a/internal/proofstore/tikv/store.go
+++ b/internal/proofstore/tikv/store.go
@@ -383,6 +383,8 @@ const (
 	prefixRecordByToken  = "record/by-storage-token/"
 	prefixManifest       = "manifest/"
 	prefixRoot           = "root/"
+	prefixBatchTreeLeaf  = "batch-tree/leaf/"
+	prefixBatchTreeNode  = "batch-tree/node/"
 	prefixGlobalLeaf     = "global/leaf/"
 	prefixGlobalBatch    = "global/leaf-by-batch/"
 	prefixGlobalNode     = "global/node/"
@@ -848,6 +850,14 @@ func rootKey(closedAtUnixN int64, batchID string) []byte {
 	k = append(k, '/')
 	k = append(k, batchID...)
 	return k
+}
+
+func batchTreeLeafKey(batchID string, leafIndex uint64) []byte {
+	return []byte(fmt.Sprintf("%s%s/%0*d", prefixBatchTreeLeaf, batchID, rootSortKeyWidth, leafIndex))
+}
+
+func batchTreeNodeKey(batchID string, level, startIndex uint64) []byte {
+	return []byte(fmt.Sprintf("%s%s/%0*d/%0*d", prefixBatchTreeNode, batchID, rootSortKeyWidth, level, rootSortKeyWidth, startIndex))
 }
 
 func isNotFound(err error) bool {
@@ -1614,6 +1624,184 @@ func (s *Store) LatestRoot(ctx context.Context) (model.BatchRoot, error) {
 		return model.BatchRoot{}, trusterr.New(trusterr.CodeNotFound, "batch root not found")
 	}
 	return roots[0], nil
+}
+
+func (s *Store) PutBatchTreeArtifacts(ctx context.Context, leaves []model.BatchTreeLeaf, nodes []model.BatchTreeNode) error {
+	if err := ctx.Err(); err != nil {
+		return trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore put batch tree artifacts canceled", err)
+	}
+	if len(leaves) == 0 {
+		return trusterr.New(trusterr.CodeInvalidArgument, "batch tree artifacts require at least one leaf")
+	}
+	batchID := leaves[0].BatchID
+	if batchID == "" {
+		return trusterr.New(trusterr.CodeInvalidArgument, "batch tree artifact batch_id is required")
+	}
+	now := time.Now().UTC().UnixNano()
+	for start := 0; start < len(leaves); start += batchArtifactChunkSize {
+		end := start + batchArtifactChunkSize
+		if end > len(leaves) {
+			end = len(leaves)
+		}
+		batch := s.db.NewBatch()
+		for i := start; i < end; i++ {
+			leaf := leaves[i]
+			if leaf.BatchID != batchID {
+				_ = batch.Close()
+				return trusterr.New(trusterr.CodeInvalidArgument, "batch tree leaves must share batch_id")
+			}
+			if leaf.SchemaVersion == "" {
+				leaf.SchemaVersion = model.SchemaBatchTreeLeaf
+			}
+			if leaf.CreatedAtUnixN == 0 {
+				leaf.CreatedAtUnixN = now
+			}
+			data, err := cborx.Marshal(leaf)
+			if err != nil {
+				_ = batch.Close()
+				return err
+			}
+			if err := stageSet(batch, batchTreeLeafKey(leaf.BatchID, leaf.LeafIndex), data); err != nil {
+				_ = batch.Close()
+				return trusterr.Wrap(trusterr.CodeDataLoss, "stage batch tree leaf", err)
+			}
+		}
+		if err := batch.Commit(s.artifactWriteOptions()); err != nil {
+			_ = batch.Close()
+			return trusterr.Wrap(trusterr.CodeDataLoss, "commit batch tree leaves", err)
+		}
+		if err := batch.Close(); err != nil {
+			return trusterr.Wrap(trusterr.CodeDataLoss, "close batch tree leaves", err)
+		}
+	}
+	for start := 0; start < len(nodes); start += batchArtifactChunkSize {
+		end := start + batchArtifactChunkSize
+		if end > len(nodes) {
+			end = len(nodes)
+		}
+		batch := s.db.NewBatch()
+		for i := start; i < end; i++ {
+			node := nodes[i]
+			if node.BatchID != batchID {
+				_ = batch.Close()
+				return trusterr.New(trusterr.CodeInvalidArgument, "batch tree nodes must share batch_id")
+			}
+			if node.Width == 0 {
+				_ = batch.Close()
+				return trusterr.New(trusterr.CodeInvalidArgument, "batch tree node width is required")
+			}
+			if node.SchemaVersion == "" {
+				node.SchemaVersion = model.SchemaBatchTreeNode
+			}
+			if node.CreatedAtUnixN == 0 {
+				node.CreatedAtUnixN = now
+			}
+			data, err := cborx.Marshal(node)
+			if err != nil {
+				_ = batch.Close()
+				return err
+			}
+			if err := stageSet(batch, batchTreeNodeKey(node.BatchID, node.Level, node.StartIndex), data); err != nil {
+				_ = batch.Close()
+				return trusterr.Wrap(trusterr.CodeDataLoss, "stage batch tree node", err)
+			}
+		}
+		if err := batch.Commit(s.artifactWriteOptions()); err != nil {
+			_ = batch.Close()
+			return trusterr.Wrap(trusterr.CodeDataLoss, "commit batch tree nodes", err)
+		}
+		if err := batch.Close(); err != nil {
+			return trusterr.Wrap(trusterr.CodeDataLoss, "close batch tree nodes", err)
+		}
+	}
+	return nil
+}
+
+func (s *Store) ListBatchTreeLeaves(ctx context.Context, opts model.BatchTreeLeafListOptions) ([]model.BatchTreeLeaf, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list batch tree leaves canceled", err)
+	}
+	if opts.BatchID == "" {
+		return nil, trusterr.New(trusterr.CodeInvalidArgument, "batch_id is required")
+	}
+	limit := normaliseRecordLimit(opts.Limit)
+	prefix := fmt.Sprintf("%s%s/", prefixBatchTreeLeaf, opts.BatchID)
+	lower, upper := prefixBounds(prefix)
+	iter, err := s.db.NewIter(&iterOptions{LowerBound: lower, UpperBound: upper})
+	if err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "open batch tree leaf iterator", err)
+	}
+	defer iter.Close()
+	ok := iter.First()
+	if opts.HasAfter {
+		ok = iter.SeekGE(batchTreeLeafKey(opts.BatchID, opts.AfterLeafIndex))
+	}
+	leaves := make([]model.BatchTreeLeaf, 0, limit)
+	for ; ok; ok = iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list batch tree leaves canceled", err)
+		}
+		if len(leaves) >= limit {
+			break
+		}
+		var leaf model.BatchTreeLeaf
+		if err := cborx.UnmarshalLimit(iter.Value(), &leaf, maxStoredObjectBytes); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "decode batch tree leaf", err)
+		}
+		if opts.HasAfter && leaf.LeafIndex <= opts.AfterLeafIndex {
+			continue
+		}
+		leaves = append(leaves, leaf)
+	}
+	if err := iter.Error(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "iterate batch tree leaves", err)
+	}
+	return leaves, nil
+}
+
+func (s *Store) ListBatchTreeNodes(ctx context.Context, opts model.BatchTreeNodeListOptions) ([]model.BatchTreeNode, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list batch tree nodes canceled", err)
+	}
+	if opts.BatchID == "" {
+		return nil, trusterr.New(trusterr.CodeInvalidArgument, "batch_id is required")
+	}
+	limit := normaliseRecordLimit(opts.Limit)
+	prefix := fmt.Sprintf("%s%s/%0*d/", prefixBatchTreeNode, opts.BatchID, rootSortKeyWidth, opts.Level)
+	lower, upper := prefixBounds(prefix)
+	iter, err := s.db.NewIter(&iterOptions{LowerBound: lower, UpperBound: upper})
+	if err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "open batch tree node iterator", err)
+	}
+	defer iter.Close()
+	ok := iter.SeekGE(batchTreeNodeKey(opts.BatchID, opts.Level, opts.StartIndex))
+	if opts.HasAfter && opts.AfterStartIndex >= opts.StartIndex {
+		ok = iter.SeekGE(batchTreeNodeKey(opts.BatchID, opts.Level, opts.AfterStartIndex))
+	}
+	nodes := make([]model.BatchTreeNode, 0, limit)
+	for ; ok; ok = iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list batch tree nodes canceled", err)
+		}
+		if len(nodes) >= limit {
+			break
+		}
+		var node model.BatchTreeNode
+		if err := cborx.UnmarshalLimit(iter.Value(), &node, maxStoredObjectBytes); err != nil {
+			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "decode batch tree node", err)
+		}
+		if node.StartIndex < opts.StartIndex {
+			continue
+		}
+		if opts.HasAfter && node.StartIndex <= opts.AfterStartIndex {
+			continue
+		}
+		nodes = append(nodes, node)
+	}
+	if err := iter.Error(); err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "iterate batch tree nodes", err)
+	}
+	return nodes, nil
 }
 
 func (s *Store) PutManifest(ctx context.Context, manifest model.BatchManifest) error {

--- a/sdk/grpc_transport_test.go
+++ b/sdk/grpc_transport_test.go
@@ -157,3 +157,15 @@ func (grpcTestBatch) RootsPage(context.Context, model.RootListOptions) ([]model.
 func (grpcTestBatch) LatestRoot(context.Context) (model.BatchRoot, error) {
 	return model.BatchRoot{SchemaVersion: model.SchemaBatchRoot, BatchID: "batch-latest", TreeSize: 3}, nil
 }
+
+func (grpcTestBatch) Manifest(context.Context, string) (model.BatchManifest, error) {
+	return model.BatchManifest{SchemaVersion: model.SchemaBatchManifest, BatchID: "batch-1", TreeSize: 1}, nil
+}
+
+func (grpcTestBatch) BatchTreeLeaves(context.Context, model.BatchTreeLeafListOptions) ([]model.BatchTreeLeaf, error) {
+	return []model.BatchTreeLeaf{{SchemaVersion: model.SchemaBatchTreeLeaf, BatchID: "batch-1", RecordID: "tr1record", LeafIndex: 0}}, nil
+}
+
+func (grpcTestBatch) BatchTreeNodes(context.Context, model.BatchTreeNodeListOptions) ([]model.BatchTreeNode, error) {
+	return []model.BatchTreeNode{{SchemaVersion: model.SchemaBatchTreeNode, BatchID: "batch-1", Level: 0, StartIndex: 0, Width: 1}}, nil
+}


### PR DESCRIPTION
## Summary
- Adds persistent, paged batch Merkle tree leaf/node indexes across local, Pebble, and TiKV proofstores.
- Exposes public `/v1` batch history/detail/tree and global tree browsing APIs for high-volume on-demand inspection.
- Adds Admin Web batch history, batch detail, proof path, batch/global Canvas tree explorers, and lazy node expansion without full-tree loading.

## Test plan
- `go test -mod=readonly ./...`
- `go test -mod=readonly ./internal/httpapi ./internal/grpcapi ./internal/globallog`
- `npm run test:unit`
- `npm run test:unit -- MerkleTreeExplorer GlobalTree api`
- `npm run test:e2e`
- `npm run build`

Closes #121
Closes #123