### PR TITLE
fix(ci): wait for batch tree nodes in integration test

### DIFF
--- a/internal/batch/service_test.go
+++ b/internal/batch/service_test.go
@@ -47,10 +47,7 @@ func TestServiceCommitsFullBatch(t *testing.T) {
 	if len(leaves) != 2 || leaves[0].RecordID != "tr1a" || leaves[1].RecordID != "tr1b" {
 		t.Fatalf("ListBatchTreeLeaves() = %+v", leaves)
 	}
-	nodes, err := store.ListBatchTreeNodes(context.Background(), model.BatchTreeNodeListOptions{BatchID: root.BatchID, Level: 1, Limit: 10})
-	if err != nil {
-		t.Fatalf("ListBatchTreeNodes() error = %v", err)
-	}
+	nodes := waitForBatchTreeNodes(t, store, root.BatchID, 1, 1)
 	if len(nodes) != 1 || nodes[0].Width != 2 {
 		t.Fatalf("ListBatchTreeNodes() = %+v", nodes)
 	}
@@ -491,6 +488,22 @@ func waitForBatchTreeLeaves(t *testing.T, store proofstore.LocalStore, batchID s
 	}
 	leaves, err := store.ListBatchTreeLeaves(context.Background(), model.BatchTreeLeafListOptions{BatchID: batchID, Limit: want})
 	t.Fatalf("ListBatchTreeLeaves(%q) after wait = %+v err=%v want len=%d", batchID, leaves, err, want)
+	return nil
+}
+
+func waitForBatchTreeNodes(t *testing.T, store proofstore.LocalStore, batchID string, level uint64, want int) []model.BatchTreeNode {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	opts := model.BatchTreeNodeListOptions{BatchID: batchID, Level: level, Limit: want}
+	for time.Now().Before(deadline) {
+		nodes, err := store.ListBatchTreeNodes(context.Background(), opts)
+		if err == nil && len(nodes) >= want {
+			return nodes
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	nodes, err := store.ListBatchTreeNodes(context.Background(), opts)
+	t.Fatalf("ListBatchTreeNodes(%q, level=%d) after wait = %+v err=%v want len=%d", batchID, level, nodes, err, want)
 	return nil
 }
 

--- a/internal/proofstore/local.go
+++ b/internal/proofstore/local.go
@@ -335,6 +335,7 @@ func (s LocalStore) PutBatchTreeArtifacts(ctx context.Context, leaves []model.Ba
 		return trusterr.New(trusterr.CodeInvalidArgument, "batch tree artifact batch_id is required")
 	}
 	now := time.Now().UTC().UnixNano()
+	normalizedLeaves := make([]model.BatchTreeLeaf, len(leaves))
 	for i := range leaves {
 		if err := ctx.Err(); err != nil {
 			return trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore put batch tree artifacts canceled", err)
@@ -349,10 +350,9 @@ func (s LocalStore) PutBatchTreeArtifacts(ctx context.Context, leaves []model.Ba
 		if leaf.CreatedAtUnixN == 0 {
 			leaf.CreatedAtUnixN = now
 		}
-		if err := writeCBORAtomic(s.batchTreeLeafPath(leaf.BatchID, leaf.LeafIndex), leaf); err != nil {
-			return trusterr.Wrap(trusterr.CodeDataLoss, "write batch tree leaf", err)
-		}
+		normalizedLeaves[i] = leaf
 	}
+	normalizedNodes := make([]model.BatchTreeNode, len(nodes))
 	for i := range nodes {
 		if err := ctx.Err(); err != nil {
 			return trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore put batch tree artifacts canceled", err)
@@ -370,8 +370,21 @@ func (s LocalStore) PutBatchTreeArtifacts(ctx context.Context, leaves []model.Ba
 		if node.CreatedAtUnixN == 0 {
 			node.CreatedAtUnixN = now
 		}
+		normalizedNodes[i] = node
+	}
+	// LocalStore cannot make this multi-file artifact fully atomic. Write
+	// internal nodes first and leaves last so a visible leaf is a better
+	// signal that the tree projection is ready for readers.
+	for i := range normalizedNodes {
+		node := normalizedNodes[i]
 		if err := writeCBORAtomic(s.batchTreeNodePath(node.BatchID, node.Level, node.StartIndex), node); err != nil {
 			return trusterr.Wrap(trusterr.CodeDataLoss, "write batch tree node", err)
+		}
+	}
+	for i := range normalizedLeaves {
+		leaf := normalizedLeaves[i]
+		if err := writeCBORAtomic(s.batchTreeLeafPath(leaf.BatchID, leaf.LeafIndex), leaf); err != nil {
+			return trusterr.Wrap(trusterr.CodeDataLoss, "write batch tree leaf", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Fixes the batch integration test race where leaves could become visible before internal batch tree nodes in the local proofstore.
- Writes local batch tree nodes before leaves so a visible leaf is a better readiness signal for the tree projection.
- Polls for the expected batch tree node directly in `TestServiceCommitsFullBatch`.

## Test plan
- `go test -count=1 -mod=readonly -tags=integration ./internal/batch -run TestServiceCommitsFullBatch -v`
- `go test -count=1 -mod=readonly ./internal/batch ./internal/proofstore/...`
- `go test -count=1 -mod=readonly -tags=integration ./internal/batch`
- `go test -count=1 -mod=readonly -tags=integration ./...`

Closes #127

Made with [Cursor](https://cursor.com)