### PR TITLE
fix: harden verification and input decoding

### DIFF
--- a/cmd/trustdb/verify_cmd.go
+++ b/cmd/trustdb/verify_cmd.go
@@ -314,7 +314,7 @@ func fetchAnchorResult(ctx context.Context, client *http.Client, serverURL strin
 		return nil, fmt.Errorf("verify: GET %s: %s: %s", endpoint, resp.Status, strings.TrimSpace(string(body)))
 	}
 	var env anchorResponseEnvelope
-	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+	if err := decodeSingleJSON(resp.Body, &env); err != nil {
 		return nil, fmt.Errorf("decode anchor response: %w", err)
 	}
 	if env.Result == nil {
@@ -337,7 +337,21 @@ func getJSON(ctx context.Context, client *http.Client, endpoint string, dst any)
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
 		return fmt.Errorf("GET %s: %s: %s", endpoint, resp.Status, strings.TrimSpace(string(body)))
 	}
-	return json.NewDecoder(resp.Body).Decode(dst)
+	return decodeSingleJSON(resp.Body, dst)
+}
+
+func decodeSingleJSON(r io.Reader, dst any) error {
+	decoder := json.NewDecoder(r)
+	if err := decoder.Decode(dst); err != nil {
+		return err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err == nil {
+		return fmt.Errorf("trailing JSON data")
+	} else if err != io.EOF {
+		return err
+	}
+	return nil
 }
 
 // joinURL concatenates a base URL (e.g. "http://host:8080") with a

--- a/cmd/trustdb/verify_cmd_test.go
+++ b/cmd/trustdb/verify_cmd_test.go
@@ -32,6 +32,15 @@ import (
 	"github.com/ryan-wong-coder/trustdb/internal/wal"
 )
 
+func TestDecodeSingleJSONRejectsTrailingData(t *testing.T) {
+	t.Parallel()
+	var dst map[string]bool
+	err := decodeSingleJSON(bytes.NewBufferString(`{"ok":true}{}`), &dst)
+	if err == nil {
+		t.Fatal("decodeSingleJSON() error = nil, want trailing JSON rejection")
+	}
+}
+
 // TestVerifyCmdRemoteAnchor spins up an in-process serve backed by a
 // FileSink, submits a single claim, waits for the L5 anchor to be
 // published, then invokes `trustdb verify --server=... --record=...`

--- a/internal/adminweb/adminweb_test.go
+++ b/internal/adminweb/adminweb_test.go
@@ -1,6 +1,7 @@
 package adminweb
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -179,6 +180,23 @@ func TestProxyGETOnly(t *testing.T) {
 	}
 }
 
+func TestDecodeJSONBodyLimitRejectsTrailingData(t *testing.T) {
+	t.Parallel()
+	var body loginBody
+	err := decodeJSONBodyLimit(strings.NewReader(`{"username":"op","password":"x"}{}`), &body, maxLoginBodyBytes)
+	if err == nil || !strings.Contains(err.Error(), "trailing json data") {
+		t.Fatalf("decodeJSONBodyLimit() error = %v, want trailing json data", err)
+	}
+}
+
+func TestReadBodyLimitRejectsOversizedBody(t *testing.T) {
+	t.Parallel()
+	_, err := readBodyLimit(strings.NewReader("abcd"), 3)
+	if !errors.Is(err, errRequestBodyTooLarge) {
+		t.Fatalf("readBodyLimit() error = %v, want errRequestBodyTooLarge", err)
+	}
+}
+
 func TestAdminMountServesSPAEntrypoints(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()
@@ -214,5 +232,34 @@ func TestAdminMountServesSPAEntrypoints(t *testing.T) {
 	}
 	if rec.Body.String() != "console.log('ok')" {
 		t.Fatalf("asset body = %q", rec.Body.String())
+	}
+}
+
+func TestSPAFileServerRejectsSiblingPrefixTraversal(t *testing.T) {
+	t.Parallel()
+	parent := t.TempDir()
+	root := filepath.Join(parent, "web")
+	sibling := filepath.Join(parent, "web_evil")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(sibling, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "index.html"), []byte("<!doctype html><title>admin</title>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sibling, "secret.txt"), []byte("outside-secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/../web_evil/secret.txt", nil)
+	rec := httptest.NewRecorder()
+	spaFileServer(root).ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d body=%q, want 404", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "outside-secret") {
+		t.Fatalf("served file outside web root: %q", rec.Body.String())
 	}
 }

--- a/internal/adminweb/handler.go
+++ b/internal/adminweb/handler.go
@@ -94,9 +94,20 @@ type loginBody struct {
 	Password string `json:"password"`
 }
 
+const (
+	maxLoginBodyBytes  int64 = 1 << 20
+	maxConfigBodyBytes int64 = 4 << 20
+)
+
+var errRequestBodyTooLarge = errors.New("request body too large")
+
 func (h *handler) postSession(w http.ResponseWriter, r *http.Request) {
 	var body loginBody
-	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&body); err != nil {
+	if err := decodeJSONBodyLimit(r.Body, &body, maxLoginBodyBytes); err != nil {
+		if errors.Is(err, errRequestBodyTooLarge) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]any{"ok": false, "error": "request too large"})
+			return
+		}
 		writeJSON(w, http.StatusBadRequest, map[string]any{"ok": false, "error": "invalid json"})
 		return
 	}
@@ -203,8 +214,12 @@ func (h *handler) putConfig(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"ok": false, "error": "no --config path; cannot write"})
 		return
 	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, 4<<20))
+	body, err := readBodyLimit(r.Body, maxConfigBodyBytes)
 	if err != nil {
+		if errors.Is(err, errRequestBodyTooLarge) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, map[string]any{"ok": false, "error": "request too large"})
+			return
+		}
 		writeJSON(w, http.StatusBadRequest, map[string]any{"ok": false, "error": "read body"})
 		return
 	}
@@ -266,6 +281,38 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
+func decodeJSONBodyLimit(r io.Reader, v any, maxBytes int64) error {
+	body, err := readBodyLimit(r, maxBytes)
+	if err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	if err := decoder.Decode(v); err != nil {
+		return err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err == nil {
+		return errors.New("trailing json data")
+	} else if err != io.EOF {
+		return err
+	}
+	return nil
+}
+
+func readBodyLimit(r io.Reader, maxBytes int64) ([]byte, error) {
+	if maxBytes <= 0 {
+		return nil, errors.New("max bytes must be positive")
+	}
+	body, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, errRequestBodyTooLarge
+	}
+	return body, nil
+}
+
 type spaHandler struct {
 	root string
 }
@@ -284,7 +331,7 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		clean = ""
 	}
 	full := filepath.Join(h.root, filepath.FromSlash(clean))
-	if !strings.HasPrefix(full, filepath.Clean(h.root)) {
+	if !pathWithinRoot(h.root, full) {
 		http.NotFound(w, r)
 		return
 	}
@@ -293,4 +340,20 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	http.ServeFile(w, r, filepath.Join(h.root, "index.html"))
+}
+
+func pathWithinRoot(root, path string) bool {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	pathAbs, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(rootAbs, pathAbs)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
 }

--- a/internal/anchor/ots_sink.go
+++ b/internal/anchor/ots_sink.go
@@ -30,6 +30,8 @@ const OtsSinkName = "ots"
 // silently misinterpreting it.
 const SchemaOtsAnchorProof = "trustdb.anchor-ots-proof.v1"
 
+const maxOtsTimestampBytes int64 = 1 << 20
+
 // DefaultOtsCalendars is the public pool used when the operator does
 // not supply --anchor-ots-calendars. We pick the well-known pool
 // domains maintained by the OTS project and Eternity Wall because they
@@ -316,7 +318,7 @@ func (s *OtsSink) submitOne(ctx context.Context, calURL string, digest []byte) O
 		return OtsCalendarTimestamp{URL: calURL, Error: err.Error(), ElapsedMillis: elapsed}
 	}
 	defer resp.Body.Close()
-	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	body, readErr := readOtsBodyLimit(resp.Body)
 	if readErr != nil {
 		return OtsCalendarTimestamp{URL: calURL, Error: fmt.Sprintf("read body: %v", readErr), StatusCode: resp.StatusCode, ElapsedMillis: elapsed}
 	}
@@ -334,6 +336,17 @@ func (s *OtsSink) submitOne(ctx context.Context, calURL string, digest []byte) O
 		StatusCode:    resp.StatusCode,
 		ElapsedMillis: elapsed,
 	}
+}
+
+func readOtsBodyLimit(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxOtsTimestampBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxOtsTimestampBytes {
+		return nil, fmt.Errorf("ots timestamp response too large: %d > %d", len(body), maxOtsTimestampBytes)
+	}
+	return body, nil
 }
 
 // DeterministicOtsAnchorID derives a stable anchor id from the STH

--- a/internal/anchor/ots_sink_test.go
+++ b/internal/anchor/ots_sink_test.go
@@ -191,6 +191,24 @@ func TestOtsSink_QuorumMissedIsTransient(t *testing.T) {
 	}
 }
 
+func TestOtsSinkRejectsOversizedCalendarResponse(t *testing.T) {
+	t.Parallel()
+	huge := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(strings.Repeat("x", int(maxOtsTimestampBytes)+1)))
+	}))
+	defer huge.Close()
+
+	sink, err := NewOtsSink(OtsSinkOptions{Calendars: []string{huge.URL}})
+	if err != nil {
+		t.Fatalf("NewOtsSink: %v", err)
+	}
+	_, err = sink.Publish(context.Background(), newTestSTH(1, newTestDigest("oversized")))
+	if err == nil || !strings.Contains(err.Error(), "too large") {
+		t.Fatalf("Publish() error = %v, want too large", err)
+	}
+}
+
 // TestOtsSink_WrongDigestSizeIsPermanent: an STH root that is not a
 // 32-byte sha256 is a configuration bug the worker can't retry its
 // way out of.

--- a/internal/anchor/ots_upgrade.go
+++ b/internal/anchor/ots_upgrade.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -178,7 +177,7 @@ func upgradeOneCalendar(
 		return out
 	}
 	defer resp.Body.Close()
-	body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	body, readErr := readOtsBodyLimit(resp.Body)
 	out.StatusCode = resp.StatusCode
 	if readErr != nil {
 		out.Error = fmt.Sprintf("read body: %v", readErr)

--- a/internal/anchor/ots_upgrade_test.go
+++ b/internal/anchor/ots_upgrade_test.go
@@ -134,6 +134,44 @@ func TestUpgradeOtsProof_UnchangedWhenServerReturnsSame(t *testing.T) {
 	}
 }
 
+func TestUpgradeOtsProofRejectsOversizedCalendarResponse(t *testing.T) {
+	t.Parallel()
+
+	digest := newTestDigest(t.Name())
+	digestHex := hex.EncodeToString(digest)
+	pending := []byte("still-pending")
+	cal := newUpgradeCalendar(t, "c1", map[string]struct {
+		Status int
+		Body   []byte
+	}{
+		digestHex: {Status: http.StatusOK, Body: []byte(strings.Repeat("x", int(maxOtsTimestampBytes)+1))},
+	})
+	defer cal.Close()
+
+	proof := &OtsAnchorProof{
+		SchemaVersion: SchemaOtsAnchorProof,
+		TreeSize:      2,
+		HashAlg:       "sha256",
+		Digest:        digest,
+		Calendars: []OtsCalendarTimestamp{
+			{URL: cal.URL, Accepted: true, RawTimestamp: pending},
+		},
+	}
+	summary, err := UpgradeOtsProof(context.Background(), proof, OtsUpgradeOptions{HTTPClient: cal.Client()})
+	if err != nil {
+		t.Fatalf("UpgradeOtsProof: %v", err)
+	}
+	if summary.Changed {
+		t.Fatal("oversized response must not mark proof changed")
+	}
+	if c := summary.Calendars[0]; !strings.Contains(c.Error, "too large") || c.Changed {
+		t.Fatalf("calendar summary = %+v, want too-large error without change", c)
+	}
+	if got := string(proof.Calendars[0].RawTimestamp); got != string(pending) {
+		t.Fatalf("raw timestamp mutated: %q", got)
+	}
+}
+
 func TestUpgradeOtsProof_Error404IsNeutral(t *testing.T) {
 	t.Parallel()
 

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -704,7 +704,17 @@ func decodeCBOREntry(entry archiveEntry, v any) error {
 
 func decodeJSONEntry(entry archiveEntry, v any) error {
 	return decodeEntry(entry, func(r io.Reader) error {
-		return json.NewDecoder(r).Decode(v)
+		decoder := json.NewDecoder(r)
+		if err := decoder.Decode(v); err != nil {
+			return err
+		}
+		var extra any
+		if err := decoder.Decode(&extra); err == nil {
+			return fmt.Errorf("backup entry %s has trailing JSON data", entry.Name)
+		} else if err != io.EOF {
+			return err
+		}
+		return nil
 	})
 }
 

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"archive/tar"
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	"os"
 	"path/filepath"
@@ -193,6 +194,43 @@ func TestVerifyRejectsEntryHashMismatch(t *testing.T) {
 	}
 	if _, err := Verify(context.Background(), path); err == nil {
 		t.Fatal("Verify() error = nil, want sha256 mismatch")
+	}
+}
+
+func TestVerifyRejectsTrailingJSONData(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "trailing-json.tdbackup")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	tw := tar.NewWriter(f)
+	data := []byte(`{"schema_version":"trustdb.backup.v2"}{"schema_version":"trustdb.backup.v2"}`)
+	sum := sha256.Sum256(data)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "summary.json",
+		Mode: 0o600,
+		Size: int64(len(data)),
+		PAXRecords: map[string]string{
+			paxBackupID: "bad-backup",
+			paxOrdinal:  "1",
+			paxSHA256:   hex.EncodeToString(sum[:]),
+			paxType:     "summary",
+		},
+	}); err != nil {
+		t.Fatalf("WriteHeader: %v", err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar Close: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("file Close: %v", err)
+	}
+	if _, err := Verify(context.Background(), path); err == nil {
+		t.Fatal("Verify() error = nil, want trailing JSON error")
 	}
 }
 

--- a/internal/cborx/cborx.go
+++ b/internal/cborx/cborx.go
@@ -102,9 +102,27 @@ func DecodeReaderLimit(r io.Reader, v any, maxBytes int64) error {
 	if r == nil {
 		return errors.New("cborx: nil reader")
 	}
-	limited := io.LimitReader(r, maxBytes+1)
-	if err := decMode.NewDecoder(limited).Decode(v); err != nil {
+	limited := &io.LimitedReader{R: r, N: maxBytes + 1}
+	counting := &readerCounter{r: limited}
+	decoder := decMode.NewDecoder(counting)
+	if err := decoder.Decode(v); err != nil {
+		if counting.n > maxBytes {
+			return fmt.Errorf("cborx: payload too large: %d > %d", counting.n, maxBytes)
+		}
 		return fmt.Errorf("cborx: decode: %w", err)
+	}
+	if int64(decoder.NumBytesRead()) > maxBytes {
+		return fmt.Errorf("cborx: payload too large: %d > %d", decoder.NumBytesRead(), maxBytes)
+	}
+	if ok, err := readOne(decoder.Buffered()); err != nil {
+		return fmt.Errorf("cborx: read buffered trailing data: %w", err)
+	} else if ok {
+		return errors.New("cborx: trailing data")
+	}
+	if ok, err := readOne(counting); err != nil {
+		return fmt.Errorf("cborx: read trailing data: %w", err)
+	} else if ok {
+		return errors.New("cborx: trailing data")
 	}
 	return nil
 }
@@ -117,4 +135,27 @@ func Wellformed(data []byte) error {
 		return fmt.Errorf("cborx: wellformed: %w", err)
 	}
 	return nil
+}
+
+type readerCounter struct {
+	r io.Reader
+	n int64
+}
+
+func (r *readerCounter) Read(p []byte) (int, error) {
+	n, err := r.r.Read(p)
+	r.n += int64(n)
+	return n, err
+}
+
+func readOne(r io.Reader) (bool, error) {
+	var b [1]byte
+	n, err := r.Read(b[:])
+	if n > 0 {
+		return true, nil
+	}
+	if err == io.EOF {
+		return false, nil
+	}
+	return false, err
 }

--- a/internal/cborx/cborx_test.go
+++ b/internal/cborx/cborx_test.go
@@ -2,6 +2,7 @@ package cborx
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -74,5 +75,34 @@ func TestUnmarshalLimit(t *testing.T) {
 	var got sample
 	if err := UnmarshalLimit(data, &got, len(data)-1); err == nil {
 		t.Fatal("UnmarshalLimit() error = nil, want size error")
+	}
+}
+
+func TestDecodeReaderLimitRejectsTrailingData(t *testing.T) {
+	t.Parallel()
+
+	data, err := Marshal(sample{A: "x", B: 7})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	data = append(data, 0xf6) // valid second CBOR item (null)
+	var got sample
+	err = DecodeReaderLimit(bytes.NewReader(data), &got, int64(len(data)))
+	if err == nil || !strings.Contains(err.Error(), "trailing data") {
+		t.Fatalf("DecodeReaderLimit() error = %v, want trailing data", err)
+	}
+}
+
+func TestDecodeReaderLimitRejectsOversizedSingleItem(t *testing.T) {
+	t.Parallel()
+
+	data, err := Marshal(sample{A: "x", B: 7})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	var got sample
+	err = DecodeReaderLimit(bytes.NewReader(data), &got, int64(len(data)-1))
+	if err == nil || !strings.Contains(err.Error(), "payload too large") {
+		t.Fatalf("DecodeReaderLimit() error = %v, want payload too large", err)
 	}
 }

--- a/internal/grpcapi/server.go
+++ b/internal/grpcapi/server.go
@@ -1,7 +1,6 @@
 package grpcapi
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/hex"
@@ -549,7 +548,7 @@ func decodeRecordCursor(raw string) (recordCursor, error) {
 		return recordCursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
 	}
 	var cursor recordCursor
-	if err := json.NewDecoder(bytes.NewReader(data)).Decode(&cursor); err != nil || cursor.RecordID == "" {
+	if err := json.Unmarshal(data, &cursor); err != nil || cursor.RecordID == "" {
 		return recordCursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
 	}
 	return cursor, nil
@@ -574,7 +573,7 @@ func decodeRootCursor(raw string) (rootCursor, error) {
 		return rootCursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
 	}
 	var cursor rootCursor
-	if err := json.NewDecoder(bytes.NewReader(data)).Decode(&cursor); err != nil || cursor.BatchID == "" {
+	if err := json.Unmarshal(data, &cursor); err != nil || cursor.BatchID == "" {
 		return rootCursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
 	}
 	return cursor, nil
@@ -598,7 +597,7 @@ func decodeUint64Cursor(raw string) (uint64Cursor, error) {
 		return uint64Cursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
 	}
 	var cursor uint64Cursor
-	if err := json.NewDecoder(bytes.NewReader(data)).Decode(&cursor); err != nil {
+	if err := json.Unmarshal(data, &cursor); err != nil {
 		return uint64Cursor{}, trusterr.New(trusterr.CodeInvalidArgument, "cursor is invalid")
 	}
 	return cursor, nil

--- a/internal/grpcapi/server_test.go
+++ b/internal/grpcapi/server_test.go
@@ -2,6 +2,7 @@ package grpcapi
 
 import (
 	"context"
+	"encoding/base64"
 	"testing"
 
 	"github.com/ryan-wong-coder/trustdb/internal/model"
@@ -20,6 +21,25 @@ func TestNewServerNormalizesTypedNilGlobalService(t *testing.T) {
 	_, err := server.GetGlobalProof(context.Background(), &GetGlobalProofRequest{BatchID: "batch-1"})
 	if status.Code(err) != codes.FailedPrecondition {
 		t.Fatalf("GetGlobalProof status = %v, want %v err=%v", status.Code(err), codes.FailedPrecondition, err)
+	}
+}
+
+func TestDecodeCursorsRejectTrailingJSONData(t *testing.T) {
+	t.Parallel()
+
+	recordRaw := base64.RawURLEncoding.EncodeToString([]byte(`{"t":1,"r":"rec-1"}{}`))
+	if _, err := decodeRecordCursor(recordRaw); err == nil {
+		t.Fatal("decodeRecordCursor() error = nil, want trailing JSON rejection")
+	}
+
+	rootRaw := base64.RawURLEncoding.EncodeToString([]byte(`{"t":1,"b":"batch-1"}{}`))
+	if _, err := decodeRootCursor(rootRaw); err == nil {
+		t.Fatal("decodeRootCursor() error = nil, want trailing JSON rejection")
+	}
+
+	uint64Raw := base64.RawURLEncoding.EncodeToString([]byte(`{"v":1}{}`))
+	if _, err := decodeUint64Cursor(uint64Raw); err == nil {
+		t.Fatal("decodeUint64Cursor() error = nil, want trailing JSON rejection")
 	}
 }
 

--- a/internal/verify/anchor_test.go
+++ b/internal/verify/anchor_test.go
@@ -1,6 +1,9 @@
 package verify
 
 import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -19,6 +22,72 @@ func newGlobalProofWithSTH(treeSize uint64, root []byte) model.GlobalLogProof {
 			TreeSize:      treeSize,
 			RootHash:      root,
 		},
+	}
+}
+
+func writeOtsVaruint(buf *bytes.Buffer, v uint64) {
+	for {
+		c := byte(v & 0x7f)
+		v >>= 7
+		if v != 0 {
+			c |= 0x80
+		}
+		buf.WriteByte(c)
+		if v == 0 {
+			return
+		}
+	}
+}
+
+func writeOtsVarbytes(buf *bytes.Buffer, p []byte) {
+	writeOtsVaruint(buf, uint64(len(p)))
+	buf.Write(p)
+}
+
+func pendingOtsTimestamp(t *testing.T, uri string) []byte {
+	t.Helper()
+	magic, err := hex.DecodeString("83dfe30d2ef90c8e")
+	if err != nil {
+		t.Fatalf("decode pending magic: %v", err)
+	}
+	var payload bytes.Buffer
+	writeOtsVarbytes(&payload, []byte(uri))
+
+	var raw bytes.Buffer
+	raw.WriteByte(0x00)
+	raw.Write(magic)
+	writeOtsVarbytes(&raw, payload.Bytes())
+	return raw.Bytes()
+}
+
+func otsAnchorResult(t *testing.T, proof model.GlobalLogProof, digest []byte, timestamp []byte) model.STHAnchorResult {
+	t.Helper()
+	otsProof := anchor.OtsAnchorProof{
+		SchemaVersion: anchor.SchemaOtsAnchorProof,
+		TreeSize:      proof.STH.TreeSize,
+		HashAlg:       model.DefaultHashAlg,
+		Digest:        digest,
+		Calendars: []anchor.OtsCalendarTimestamp{
+			{
+				URL:          "https://a.pool.opentimestamps.org",
+				Accepted:     true,
+				RawTimestamp: timestamp,
+				StatusCode:   200,
+			},
+		},
+	}
+	proofBytes, err := json.Marshal(otsProof)
+	if err != nil {
+		t.Fatalf("marshal ots proof: %v", err)
+	}
+	return model.STHAnchorResult{
+		SchemaVersion: model.SchemaSTHAnchorResult,
+		TreeSize:      proof.STH.TreeSize,
+		SinkName:      anchor.OtsSinkName,
+		AnchorID:      anchor.DeterministicOtsAnchorID(proof.STH),
+		RootHash:      proof.STH.RootHash,
+		STH:           proof.STH,
+		Proof:         proofBytes,
 	}
 }
 
@@ -56,11 +125,29 @@ func TestAnchorConsistencyNoopSinkOK(t *testing.T) {
 	}
 }
 
-func TestAnchorConsistencyUnknownSinkSkipsIDCheck(t *testing.T) {
+func TestAnchorConsistencyOtsSinkOK(t *testing.T) {
 	t.Parallel()
-	// Unknown sinks carry their own proof format; AnchorConsistency
-	// must pass as long as tree_size / root_hash agree because the
-	// sink-specific verifier runs separately.
+	root := bytes.Repeat([]byte{0x42}, 32)
+	proof := newGlobalProofWithSTH(9, root)
+	ar := otsAnchorResult(t, proof, root, pendingOtsTimestamp(t, "https://a.pool.opentimestamps.org"))
+	if err := AnchorConsistency(proof, ar); err != nil {
+		t.Fatalf("AnchorConsistency (ots): %v", err)
+	}
+}
+
+func TestAnchorConsistencyRejectsOtsDigestMismatch(t *testing.T) {
+	t.Parallel()
+	root := bytes.Repeat([]byte{0x42}, 32)
+	proof := newGlobalProofWithSTH(9, root)
+	ar := otsAnchorResult(t, proof, bytes.Repeat([]byte{0x24}, 32), pendingOtsTimestamp(t, "https://a.pool.opentimestamps.org"))
+	err := AnchorConsistency(proof, ar)
+	if err == nil || !strings.Contains(err.Error(), "digest mismatch") {
+		t.Fatalf("want ots digest mismatch, got %v", err)
+	}
+}
+
+func TestAnchorConsistencyRejectsUnknownSink(t *testing.T) {
+	t.Parallel()
 	root := []byte{9, 9}
 	proof := newGlobalProofWithSTH(9, root)
 	ar := model.STHAnchorResult{
@@ -71,8 +158,9 @@ func TestAnchorConsistencyUnknownSinkSkipsIDCheck(t *testing.T) {
 		RootHash:      root,
 		STH:           proof.STH,
 	}
-	if err := AnchorConsistency(proof, ar); err != nil {
-		t.Fatalf("AnchorConsistency (unknown sink): %v", err)
+	err := AnchorConsistency(proof, ar)
+	if err == nil || !strings.Contains(err.Error(), "unsupported anchor sink") {
+		t.Fatalf("want unsupported sink error, got %v", err)
 	}
 }
 

--- a/internal/verify/proofbundle_test.go
+++ b/internal/verify/proofbundle_test.go
@@ -1,0 +1,174 @@
+package verify
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ryan-wong-coder/trustdb/internal/app"
+	"github.com/ryan-wong-coder/trustdb/internal/claim"
+	"github.com/ryan-wong-coder/trustdb/internal/globallog"
+	"github.com/ryan-wong-coder/trustdb/internal/model"
+	"github.com/ryan-wong-coder/trustdb/internal/proofstore"
+	"github.com/ryan-wong-coder/trustdb/internal/trustcrypto"
+	"github.com/ryan-wong-coder/trustdb/internal/wal"
+)
+
+type proofBundleFixture struct {
+	raw        []byte
+	bundle     model.ProofBundle
+	keys       TrustedKeys
+	serverPriv ed25519.PrivateKey
+}
+
+func newProofBundleFixture(t *testing.T) proofBundleFixture {
+	t.Helper()
+	clientPub, clientPriv, err := trustcrypto.GenerateEd25519Key()
+	if err != nil {
+		t.Fatalf("Generate client key: %v", err)
+	}
+	serverPub, serverPriv, err := trustcrypto.GenerateEd25519Key()
+	if err != nil {
+		t.Fatalf("Generate server key: %v", err)
+	}
+	raw := []byte("trustdb verify regression payload")
+	contentHash, err := trustcrypto.HashBytes(model.DefaultHashAlg, raw)
+	if err != nil {
+		t.Fatalf("HashBytes: %v", err)
+	}
+	c, err := claim.NewFileClaim(
+		"tenant-a",
+		"client-a",
+		"client-key",
+		time.Unix(100, 0),
+		bytes.Repeat([]byte{1}, 16),
+		"idem-a",
+		model.Content{HashAlg: model.DefaultHashAlg, ContentHash: contentHash, ContentLength: int64(len(raw))},
+		model.Metadata{EventType: "file.snapshot"},
+	)
+	if err != nil {
+		t.Fatalf("NewFileClaim: %v", err)
+	}
+	signed, err := claim.Sign(c, clientPriv)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	w, err := wal.OpenWriter(filepath.Join(t.TempDir(), "000000000001.wal"), 1)
+	if err != nil {
+		t.Fatalf("OpenWriter: %v", err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+
+	engine := app.LocalEngine{
+		ServerID:         "server-a",
+		LogID:            "log-a",
+		ServerKeyID:      "server-key",
+		ClientPublicKey:  clientPub,
+		ServerPrivateKey: serverPriv,
+		WAL:              w,
+		Now:              func() time.Time { return time.Unix(200, 0) },
+	}
+	record, accepted, _, err := engine.Submit(context.Background(), signed)
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	bundles, err := engine.CommitBatch(
+		"batch-a",
+		time.Unix(300, 0),
+		[]model.SignedClaim{signed},
+		[]model.ServerRecord{record},
+		[]model.AcceptedReceipt{accepted},
+	)
+	if err != nil {
+		t.Fatalf("CommitBatch: %v", err)
+	}
+	return proofBundleFixture{
+		raw:    raw,
+		bundle: bundles[0],
+		keys: TrustedKeys{
+			ClientPublicKey: clientPub,
+			ServerPublicKey: serverPub,
+		},
+		serverPriv: serverPriv,
+	}
+}
+
+func globalProofForBundle(t *testing.T, f proofBundleFixture) model.GlobalLogProof {
+	t.Helper()
+	ctx := context.Background()
+	store := proofstore.LocalStore{Root: t.TempDir()}
+	svc, err := globallog.New(globallog.Options{
+		Store:      store,
+		NodeID:     f.bundle.NodeID,
+		LogID:      f.bundle.LogID,
+		KeyID:      "server-key",
+		PrivateKey: f.serverPriv,
+		Clock:      func() time.Time { return time.Unix(400, 0).UTC() },
+	})
+	if err != nil {
+		t.Fatalf("globallog.New: %v", err)
+	}
+	sth, err := svc.AppendBatchRoot(ctx, model.BatchRoot{
+		SchemaVersion: model.SchemaBatchRoot,
+		NodeID:        f.bundle.NodeID,
+		LogID:         f.bundle.LogID,
+		BatchID:       f.bundle.CommittedReceipt.BatchID,
+		BatchRoot:     append([]byte(nil), f.bundle.CommittedReceipt.BatchRoot...),
+		TreeSize:      f.bundle.BatchProof.TreeSize,
+		ClosedAtUnixN: f.bundle.CommittedReceipt.ClosedAtUnixN,
+	})
+	if err != nil {
+		t.Fatalf("AppendBatchRoot: %v", err)
+	}
+	proof, err := svc.InclusionProof(ctx, f.bundle.CommittedReceipt.BatchID, sth.TreeSize)
+	if err != nil {
+		t.Fatalf("InclusionProof: %v", err)
+	}
+	return proof
+}
+
+func TestProofBundleRejectsAcceptedReceiptRecordIDMismatch(t *testing.T) {
+	t.Parallel()
+	f := newProofBundleFixture(t)
+	f.bundle.AcceptedReceipt.RecordID = "tr1wrong"
+
+	_, err := ProofBundle(bytes.NewReader(f.raw), f.bundle, f.keys)
+	if err == nil || !strings.Contains(err.Error(), "accepted receipt record_id mismatch") {
+		t.Fatalf("ProofBundle error = %v, want accepted receipt record_id mismatch", err)
+	}
+}
+
+func TestProofBundleRejectsCommittedReceiptRecordIDMismatch(t *testing.T) {
+	t.Parallel()
+	f := newProofBundleFixture(t)
+	f.bundle.CommittedReceipt.RecordID = "tr1wrong"
+
+	_, err := ProofBundle(bytes.NewReader(f.raw), f.bundle, f.keys)
+	if err == nil || !strings.Contains(err.Error(), "committed receipt record_id mismatch") {
+		t.Fatalf("ProofBundle error = %v, want committed receipt record_id mismatch", err)
+	}
+}
+
+func TestProofBundleVerifiesGlobalLogSTHSignature(t *testing.T) {
+	t.Parallel()
+	f := newProofBundleFixture(t)
+	proof := globalProofForBundle(t, f)
+
+	result, err := ProofBundle(bytes.NewReader(f.raw), f.bundle, f.keys, WithGlobalProof(proof))
+	if err != nil {
+		t.Fatalf("ProofBundle with global proof: %v", err)
+	}
+	if result.ProofLevel != "L4" {
+		t.Fatalf("ProofLevel = %s, want L4", result.ProofLevel)
+	}
+
+	proof.STH.Signature.Signature[0] ^= 0xff
+	_, err = ProofBundle(bytes.NewReader(f.raw), f.bundle, f.keys, WithGlobalProof(proof))
+	if err == nil || !strings.Contains(err.Error(), "verify signed tree head") {
+		t.Fatalf("ProofBundle tampered STH error = %v, want signed tree head verification error", err)
+	}
+}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -3,6 +3,8 @@ package verify
 import (
 	"bytes"
 	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -81,6 +83,9 @@ func ProofBundle(raw io.Reader, bundle model.ProofBundle, keys TrustedKeys, opts
 	if verified.RecordID != bundle.RecordID || verified.RecordID != bundle.ServerRecord.RecordID {
 		return Result{}, fmt.Errorf("verify: record id mismatch")
 	}
+	if err := validateBundleBindings(bundle, verified); err != nil {
+		return Result{}, err
+	}
 	if err := receipt.VerifyAccepted(bundle.AcceptedReceipt, keys.ServerPublicKey); err != nil {
 		return Result{}, err
 	}
@@ -110,7 +115,7 @@ func ProofBundle(raw io.Reader, bundle model.ProofBundle, keys TrustedKeys, opts
 		ProofLevel: prooflevel.Evaluate(evidence).String(),
 	}
 	if o.global != nil {
-		if err := GlobalLogConsistency(bundle, *o.global); err != nil {
+		if err := VerifyGlobalLogProof(bundle, *o.global, keys.ServerPublicKey); err != nil {
 			return Result{}, err
 		}
 		evidence.GlobalLogProof = true
@@ -131,9 +136,88 @@ func ProofBundle(raw io.Reader, bundle model.ProofBundle, keys TrustedKeys, opts
 	return result, nil
 }
 
+func validateBundleBindings(bundle model.ProofBundle, verified claim.Verified) error {
+	if bundle.ServerRecord.TenantID != bundle.SignedClaim.Claim.TenantID {
+		return fmt.Errorf("verify: server record tenant_id mismatch")
+	}
+	if bundle.ServerRecord.ClientID != bundle.SignedClaim.Claim.ClientID {
+		return fmt.Errorf("verify: server record client_id mismatch")
+	}
+	if bundle.ServerRecord.KeyID != bundle.SignedClaim.Claim.KeyID {
+		return fmt.Errorf("verify: server record key_id mismatch")
+	}
+	claimHash, err := trustcrypto.HashBytes(model.DefaultHashAlg, verified.ClaimCBOR)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(bundle.ServerRecord.ClaimHash, claimHash) {
+		return fmt.Errorf("verify: server record claim_hash mismatch")
+	}
+	sigHash, err := trustcrypto.HashBytes(model.DefaultHashAlg, bundle.SignedClaim.Signature.Signature)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(bundle.ServerRecord.ClientSignatureHash, sigHash) {
+		return fmt.Errorf("verify: server record client_signature_hash mismatch")
+	}
+	if bundle.AcceptedReceipt.RecordID != verified.RecordID {
+		return fmt.Errorf("verify: accepted receipt record_id mismatch")
+	}
+	if bundle.AcceptedReceipt.ReceivedAtUnixN != bundle.ServerRecord.ReceivedAtUnixN {
+		return fmt.Errorf("verify: accepted receipt received_at mismatch")
+	}
+	if bundle.AcceptedReceipt.WAL != bundle.ServerRecord.WAL {
+		return fmt.Errorf("verify: accepted receipt WAL mismatch")
+	}
+	if bundle.NodeID != "" && bundle.AcceptedReceipt.ServerID != "" && bundle.NodeID != bundle.AcceptedReceipt.ServerID {
+		return fmt.Errorf("verify: bundle node_id mismatch")
+	}
+	if bundle.CommittedReceipt.RecordID != verified.RecordID {
+		return fmt.Errorf("verify: committed receipt record_id mismatch")
+	}
+	if bundle.CommittedReceipt.LeafIndex != bundle.BatchProof.LeafIndex {
+		return fmt.Errorf("verify: committed receipt leaf_index mismatch")
+	}
+	if bundle.CommittedReceipt.NodeID != "" && bundle.NodeID != "" && bundle.CommittedReceipt.NodeID != bundle.NodeID {
+		return fmt.Errorf("verify: committed receipt node_id mismatch")
+	}
+	if bundle.CommittedReceipt.LogID != "" && bundle.LogID != "" && bundle.CommittedReceipt.LogID != bundle.LogID {
+		return fmt.Errorf("verify: committed receipt log_id mismatch")
+	}
+	if bundle.BatchProof.TreeAlg != model.DefaultMerkleTreeAlg {
+		return fmt.Errorf("verify: unsupported batch proof tree_alg: %s", bundle.BatchProof.TreeAlg)
+	}
+	if bundle.BatchProof.TreeSize == 0 || bundle.BatchProof.LeafIndex >= bundle.BatchProof.TreeSize {
+		return fmt.Errorf("verify: invalid batch proof leaf index")
+	}
+	return nil
+}
+
+func VerifyGlobalLogProof(bundle model.ProofBundle, proof model.GlobalLogProof, publicKey ed25519.PublicKey) error {
+	if err := GlobalLogConsistency(bundle, proof); err != nil {
+		return err
+	}
+	if err := globallog.VerifySTH(proof.STH, publicKey); err != nil {
+		return err
+	}
+	return nil
+}
+
 func GlobalLogConsistency(bundle model.ProofBundle, proof model.GlobalLogProof) error {
 	if proof.SchemaVersion != model.SchemaGlobalLogProof {
 		return fmt.Errorf("verify: unexpected global log proof schema: %s", proof.SchemaVersion)
+	}
+	if proof.STH.SchemaVersion != model.SchemaSignedTreeHead {
+		return fmt.Errorf("verify: unexpected STH schema: %s", proof.STH.SchemaVersion)
+	}
+	if proof.STH.TreeAlg != model.DefaultMerkleTreeAlg {
+		return fmt.Errorf("verify: unsupported STH tree_alg: %s", proof.STH.TreeAlg)
+	}
+	if proof.TreeSize != proof.STH.TreeSize {
+		return fmt.Errorf("verify: global proof tree_size mismatch: proof=%d sth=%d", proof.TreeSize, proof.STH.TreeSize)
+	}
+	if len(proof.STH.RootHash) != sha256.Size {
+		return fmt.Errorf("verify: STH root_hash must be sha256")
 	}
 	if proof.BatchID != bundle.CommittedReceipt.BatchID {
 		return fmt.Errorf("verify: global proof batch_id mismatch: proof=%s bundle=%s", proof.BatchID, bundle.CommittedReceipt.BatchID)
@@ -174,8 +258,9 @@ func GlobalLogConsistency(bundle model.ProofBundle, proof model.GlobalLogProof) 
 }
 
 // AnchorConsistency checks that an STHAnchorResult is bound to the same STH
-// proven by the supplied global log proof. It does not talk to the external
-// sink; sink-specific Proof bytes are verified by sink-aware tooling.
+// proven by the supplied global log proof. It does not talk to external
+// services; built-in sinks are checked locally for deterministic IDs and
+// proof envelope consistency.
 func AnchorConsistency(proof model.GlobalLogProof, ar model.STHAnchorResult) error {
 	if ar.SchemaVersion != model.SchemaSTHAnchorResult {
 		return fmt.Errorf("verify: unexpected anchor result schema: %s", ar.SchemaVersion)
@@ -204,8 +289,54 @@ func AnchorConsistency(proof model.GlobalLogProof, ar model.STHAnchorResult) err
 		if got, want := ar.AnchorID, anchor.DeterministicNoopAnchorID(proof.STH); got != want {
 			return fmt.Errorf("verify: noop sink anchor_id mismatch: got %s want %s", got, want)
 		}
+	case anchor.OtsSinkName:
+		if got, want := ar.AnchorID, anchor.DeterministicOtsAnchorID(proof.STH); got != want {
+			return fmt.Errorf("verify: ots sink anchor_id mismatch: got %s want %s", got, want)
+		}
+		if err := validateOtsAnchorProof(proof.STH, ar); err != nil {
+			return err
+		}
 	default:
-		// Unknown sink: trust the sink's own verifier to handle it.
+		return fmt.Errorf("verify: unsupported anchor sink: %s", ar.SinkName)
+	}
+	return nil
+}
+
+func validateOtsAnchorProof(sth model.SignedTreeHead, ar model.STHAnchorResult) error {
+	if len(ar.Proof) == 0 {
+		return fmt.Errorf("verify: ots anchor proof is empty")
+	}
+	var proof anchor.OtsAnchorProof
+	if err := json.Unmarshal(ar.Proof, &proof); err != nil {
+		return fmt.Errorf("verify: decode ots anchor proof: %w", err)
+	}
+	if proof.SchemaVersion != anchor.SchemaOtsAnchorProof {
+		return fmt.Errorf("verify: unexpected ots anchor proof schema: %s", proof.SchemaVersion)
+	}
+	if proof.TreeSize != sth.TreeSize {
+		return fmt.Errorf("verify: ots anchor proof tree_size mismatch")
+	}
+	if proof.HashAlg != model.DefaultHashAlg {
+		return fmt.Errorf("verify: unsupported ots anchor proof hash_alg: %s", proof.HashAlg)
+	}
+	if !bytes.Equal(proof.Digest, sth.RootHash) {
+		return fmt.Errorf("verify: ots anchor proof digest mismatch")
+	}
+	accepted := 0
+	for _, calendar := range proof.Calendars {
+		if !calendar.Accepted {
+			continue
+		}
+		accepted++
+		if len(calendar.RawTimestamp) == 0 {
+			return fmt.Errorf("verify: ots accepted calendar has empty timestamp")
+		}
+		if _, err := anchor.ParseOtsTimestamp(proof.Digest, calendar.RawTimestamp); err != nil {
+			return fmt.Errorf("verify: parse ots timestamp: %w", err)
+		}
+	}
+	if accepted == 0 {
+		return fmt.Errorf("verify: ots anchor proof has no accepted calendars")
 	}
 	return nil
 }

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -282,6 +282,28 @@ func TestClientOperationalEndpoints(t *testing.T) {
 	}
 }
 
+func TestClientMetricsRejectsOversizedResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/metrics" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(strings.Repeat("x", 1<<20+1)))
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	_, err = client.MetricsRaw(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "response body too large") {
+		t.Fatalf("MetricsRaw() error = %v, want response body too large", err)
+	}
+}
+
 func TestClientExportSingleProofFallsBackToL3WhenGlobalProofUnavailable(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/http_transport.go
+++ b/sdk/http_transport.go
@@ -299,7 +299,7 @@ func (t *httpTransport) doRaw(ctx context.Context, method, path string, query ur
 	if limit <= 0 {
 		limit = 16 << 20
 	}
-	raw, err := io.ReadAll(io.LimitReader(resp.Body, limit))
+	raw, err := readAllLimit(resp.Body, limit)
 	if err != nil {
 		return nil, &Error{Op: method, URL: endpoint, Err: err}
 	}
@@ -330,6 +330,20 @@ func setQuery(values url.Values, name, value string) {
 	if strings.TrimSpace(value) != "" {
 		values.Set(name, value)
 	}
+}
+
+func readAllLimit(r io.Reader, limit int64) ([]byte, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("response body limit must be positive")
+	}
+	body, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > limit {
+		return nil, fmt.Errorf("response body too large: %d > %d", len(body), limit)
+	}
+	return body, nil
 }
 
 func pageValues(opts ListPageOptions) url.Values {


### PR DESCRIPTION
## Summary

-

## Linked Issue

Refs #

## Scope Control

- [ ] This PR only changes files needed for the linked Issue.
- [ ] README / user-facing docs only describe behavior that is already implemented.
- [ ] No local data, keys, logs, backups, build artifacts, `doc/`, or `docs/` files are included.

## Proof Semantics

- [ ] No L1/L2/L3/L4/L5 semantic change.
- [ ] L4/L5 behavior is unchanged: L4 is batch root in Global Log; L5 is STH/global root externally anchored.
- [ ] `.tdproof`, `.tdgproof`, `.tdanchor-result`, `.sproof`, and `.tdbackup` formats are unchanged.
- [ ] If any box above is false, the Issue and this PR explain compatibility and verification impact.

## Storage, Recovery, and Scale

- [ ] No production path introduces full-scan, full-load, or full-recompute behavior.
- [ ] WAL, proofstore, global log, anchor outbox, backup, and desktop local storage boundaries are unchanged.
- [ ] If storage/recovery behavior changes, tests or manual validation cover replay/retry/idempotency.

## Validation

- [ ] `go test ./...`
- [ ] `go test -race ./...`
- [ ] `go test -tags=integration ./...`
- [ ] `go test -tags=e2e ./...`
- [ ] `cd clients/desktop && go test ./...`
- [ ] `cd clients/desktop && go test -race ./...`
- [ ] `cd clients/desktop/frontend && npm run build`
- [ ] `cd clients/desktop && wails build`

Checks not run:

-

## Risk / Rollback

-
