### PR TITLE
[codex] Harden backup archive writes

### DIFF
--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -9,11 +9,11 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -36,6 +36,8 @@ const (
 	paxOrdinal  = "trustdb.ordinal"
 	paxSHA256   = "trustdb.sha256"
 	paxType     = "trustdb.type"
+
+	encodedArchiveNamePrefix = "~"
 )
 
 type Entry struct {
@@ -97,11 +99,22 @@ func Create(ctx context.Context, store proofstore.Store, path string, opts Optio
 	if clock == nil {
 		clock = func() time.Time { return time.Now().UTC() }
 	}
-	f, err := os.Create(path)
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return Manifest{}, trusterr.Wrap(trusterr.CodeInternal, "create backup directory", err)
+	}
+	f, err := os.CreateTemp(dir, "."+filepath.Base(path)+".*.tmp")
 	if err != nil {
 		return Manifest{}, trusterr.Wrap(trusterr.CodeInternal, "create backup file", err)
 	}
-	defer f.Close()
+	tmpPath := f.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+		_ = f.Close()
+	}()
 
 	var out io.Writer = f
 	var gz *gzip.Writer
@@ -335,6 +348,13 @@ func Create(ctx context.Context, store proofstore.Store, path string, opts Optio
 	if err := closeArchive(); err != nil {
 		return Manifest{}, trusterr.Wrap(trusterr.CodeDataLoss, "close backup archive", err)
 	}
+	if err := f.Close(); err != nil {
+		return Manifest{}, trusterr.Wrap(trusterr.CodeDataLoss, "close backup file", err)
+	}
+	if err := renameReplace(tmpPath, path); err != nil {
+		return Manifest{}, trusterr.Wrap(trusterr.CodeDataLoss, "publish backup archive", err)
+	}
+	cleanup = false
 	return report, nil
 }
 
@@ -822,16 +842,68 @@ func writeRestoreCheckpoint(path string, cp RestoreCheckpoint) error {
 		return err
 	}
 	data = append(data, '\n')
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return writeFileAtomic(path, data)
 }
 
 func safeName(value string) string {
-	escaped := url.PathEscape(value)
-	return strings.ReplaceAll(escaped, "%", "_")
+	if isPlainArchiveName(value) {
+		return value
+	}
+	return encodedArchiveNamePrefix + base64.RawURLEncoding.EncodeToString([]byte(value))
+}
+
+func isPlainArchiveName(value string) bool {
+	if value == "" || value == "." || value == ".." || strings.HasPrefix(value, ".") {
+		return false
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func writeFileAtomic(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := renameReplace(tmpPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func renameReplace(src, dst string) error {
+	if err := os.Rename(src, dst); err != nil {
+		if os.IsExist(err) {
+			if removeErr := os.Remove(dst); removeErr == nil {
+				return os.Rename(src, dst)
+			}
+		}
+		return err
+	}
+	return nil
 }
 
 func normaliseCompression(value string) string {

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"archive/tar"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -158,6 +159,100 @@ func TestBackupCreateVerifyRestoreRoundTrip(t *testing.T) {
 	}
 	if _, ok, err := dst.GetGlobalLogOutboxItem(ctx, root.BatchID); err != nil || !ok {
 		t.Fatalf("GetGlobalLogOutboxItem restored ok=%v err=%v", ok, err)
+	}
+}
+
+func TestCreateDoesNotReplaceTargetOnFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	src := proofstore.LocalStore{Root: filepath.Join(t.TempDir(), "src")}
+	path := filepath.Join(t.TempDir(), "trustdb.tdbackup")
+	original := []byte("existing backup content")
+	if err := os.WriteFile(path, original, 0o600); err != nil {
+		t.Fatalf("WriteFile(original): %v", err)
+	}
+
+	if _, err := Create(ctx, src, path, Options{Compression: "none"}); err == nil {
+		t.Fatal("Create() error = nil, want canceled context error")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(target): %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("target backup was replaced on failure: got %q want %q", got, original)
+	}
+}
+
+func TestCreateUsesCollisionResistantArchiveNames(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	src := proofstore.LocalStore{Root: filepath.Join(t.TempDir(), "src")}
+	ids := []string{"rec/1", "rec_2F1"}
+	for _, id := range ids {
+		if err := src.PutBundle(ctx, model.ProofBundle{
+			SchemaVersion: model.SchemaProofBundle,
+			RecordID:      id,
+			CommittedReceipt: model.CommittedReceipt{
+				BatchID:   "batch/collide",
+				BatchRoot: repeatByte(0x11, 32),
+			},
+			BatchProof: model.BatchProof{TreeSize: 2},
+		}); err != nil {
+			t.Fatalf("PutBundle(%q): %v", id, err)
+		}
+	}
+	if err := src.PutManifest(ctx, model.BatchManifest{
+		SchemaVersion: model.SchemaBatchManifest,
+		BatchID:       "batch/collide",
+		State:         model.BatchStateCommitted,
+		TreeSize:      2,
+		BatchRoot:     repeatByte(0x11, 32),
+		RecordIDs:     ids,
+		ClosedAtUnixN: 1,
+	}); err != nil {
+		t.Fatalf("PutManifest: %v", err)
+	}
+
+	path := filepath.Join(t.TempDir(), "trustdb.tdbackup")
+	report, err := Create(ctx, src, path, Options{Compression: "none"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	names := make(map[string]struct{})
+	for _, entry := range report.Entries {
+		if entry.Type != "proof_bundle" {
+			continue
+		}
+		if _, ok := names[entry.Name]; ok {
+			t.Fatalf("duplicate proof bundle archive entry name: %q", entry.Name)
+		}
+		names[entry.Name] = struct{}{}
+	}
+	if len(names) != len(ids) {
+		t.Fatalf("proof bundle entry names = %v, want %d entries", names, len(ids))
+	}
+}
+
+func TestSafeNameAvoidsPathSegmentCollisions(t *testing.T) {
+	t.Parallel()
+
+	if safeName("rec/1") == safeName("rec_2F1") {
+		t.Fatalf("safeName still collides for escaped slash spelling")
+	}
+	if safeName("") == safeName("_") {
+		t.Fatalf("safeName still collides for empty string and underscore")
+	}
+	if got := safeName(".."); got == ".." {
+		t.Fatalf("safeName(%q) = %q, want encoded non-path segment", "..", got)
+	}
+	const plain = "batch-1_2.3"
+	if got := safeName(plain); got != plain {
+		t.Fatalf("safeName(%q) = %q, want unchanged", plain, got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- write backup archives to a sibling temp file and publish them only after tar/gzip/file close succeeds
- make restore checkpoint writes use unique temp files before rename
- replace lossy backup archive path escaping with collision-resistant base64url encoding for unsafe path segments

## Root cause
The backup creator opened the final output path before scanning store data, so early failures could truncate an existing backup. Archive entry names also used percent-escape text with percent signs replaced by underscores, which could collide for identifiers such as rec/1 and rec_2F1.

## Validation
- go test ./internal/backup
- go test ./...
- go vet ./...