### PR TITLE
[codex] Harden admin config writes

### DIFF
--- a/internal/adminweb/adminweb_test.go
+++ b/internal/adminweb/adminweb_test.go
@@ -1,6 +1,7 @@
 package adminweb
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -194,6 +195,70 @@ func TestReadBodyLimitRejectsOversizedBody(t *testing.T) {
 	_, err := readBodyLimit(strings.NewReader("abcd"), 3)
 	if !errors.Is(err, errRequestBodyTooLarge) {
 		t.Fatalf("readBodyLimit() error = %v, want errRequestBodyTooLarge", err)
+	}
+}
+
+func TestPutConfigIgnoresStaleFixedTempPathAndWritesBackup(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "trustdb.yaml")
+	previous := []byte("previous: config\n")
+	if err := os.WriteFile(configPath, previous, 0o600); err != nil {
+		t.Fatalf("WriteFile(config): %v", err)
+	}
+	staleFixedTmp := configPath + ".tmp"
+	if err := os.Mkdir(staleFixedTmp, 0o755); err != nil {
+		t.Fatalf("Mkdir(stale tmp): %v", err)
+	}
+
+	h := &handler{opts: Options{
+		ConfigPath: configPath,
+		Logger:     testLogger(),
+	}}
+	req := httptest.NewRequest(http.MethodPut, "/api/config", strings.NewReader(trustconfig.DefaultYAML))
+	rec := httptest.NewRecorder()
+	h.putConfig(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("putConfig status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		OK     bool   `json:"ok"`
+		Backup string `json:"backup"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !body.OK {
+		t.Fatalf("putConfig ok = false")
+	}
+	if body.Backup == "" {
+		t.Fatalf("putConfig backup path is empty")
+	}
+	if !strings.HasPrefix(filepath.Base(body.Backup), filepath.Base(configPath)+".bak.") {
+		t.Fatalf("backup path = %q, want prefix %q", body.Backup, filepath.Base(configPath)+".bak.")
+	}
+	backup, err := os.ReadFile(body.Backup)
+	if err != nil {
+		t.Fatalf("ReadFile(backup): %v", err)
+	}
+	if string(backup) != string(previous) {
+		t.Fatalf("backup = %q, want %q", backup, previous)
+	}
+	updated, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile(config): %v", err)
+	}
+	if string(updated) != trustconfig.DefaultYAML {
+		t.Fatalf("updated config = %q, want default yaml", updated)
+	}
+	info, err := os.Stat(staleFixedTmp)
+	if err != nil {
+		t.Fatalf("stale fixed temp path missing: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("stale fixed temp path was modified; isDir=false")
 	}
 }
 

--- a/internal/adminweb/handler.go
+++ b/internal/adminweb/handler.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/rs/zerolog"
 	trustconfig "github.com/ryan-wong-coder/trustdb/internal/config"
@@ -234,27 +233,94 @@ func (h *handler) putConfig(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
-	dir := filepath.Dir(h.opts.ConfigPath)
-	backup := filepath.Join(dir, filepath.Base(h.opts.ConfigPath)+fmt.Sprintf(".bak.%d", time.Now().UnixNano()))
+	backup := ""
 	prev, err := os.ReadFile(h.opts.ConfigPath)
-	if err == nil && len(prev) > 0 {
-		if err := os.WriteFile(backup, prev, 0o600); err != nil {
+	switch {
+	case err == nil && len(prev) > 0:
+		backup, err = writeConfigBackup(h.opts.ConfigPath, prev)
+		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]any{"ok": false, "error": fmt.Sprintf("backup: %v", err)})
 			return
 		}
-	}
-	tmp := h.opts.ConfigPath + ".tmp"
-	if err := os.WriteFile(tmp, body, 0o600); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"ok": false, "error": err.Error()})
+	case err != nil && !os.IsNotExist(err):
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"ok": false, "error": fmt.Sprintf("read existing config: %v", err)})
 		return
 	}
-	if err := os.Rename(tmp, h.opts.ConfigPath); err != nil {
-		_ = os.Remove(tmp)
+	if err := writeConfigAtomic(h.opts.ConfigPath, body); err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]any{"ok": false, "error": err.Error()})
 		return
 	}
 	h.opts.Logger.Info().Str("path", h.opts.ConfigPath).Str("backup", backup).Msg("admin wrote config file")
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "backup": backup})
+}
+
+func writeConfigBackup(configPath string, data []byte) (string, error) {
+	dir := filepath.Dir(configPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	f, err := os.CreateTemp(dir, filepath.Base(configPath)+".bak.*")
+	if err != nil {
+		return "", err
+	}
+	path := f.Name()
+	cleanup := true
+	defer func() {
+		_ = f.Close()
+		if cleanup {
+			_ = os.Remove(path)
+		}
+	}()
+	if _, err := f.Write(data); err != nil {
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+	cleanup = false
+	return path, nil
+}
+
+func writeConfigAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(dir, "."+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := f.Name()
+	cleanup := true
+	defer func() {
+		_ = f.Close()
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := f.Write(data); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := renameReplace(tmpPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func renameReplace(src, dst string) error {
+	if err := os.Rename(src, dst); err != nil {
+		if os.IsExist(err) {
+			if removeErr := os.Remove(dst); removeErr == nil {
+				return os.Rename(src, dst)
+			}
+		}
+		return err
+	}
+	return nil
 }
 
 func (h *handler) getOverlays(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- write admin config updates through unique sibling temp files before atomic replace
- create unique backup files with CreateTemp instead of timestamp/fixed names
- fail loudly if the existing config cannot be read before saving

## Root cause
The admin config writer used a fixed config.tmp path for replacement and timestamp-based backup names. A stale path or concurrent save could block or interfere with writes, and read failures on the existing config were silently ignored.

## Validation
- go test ./internal/adminweb
- go test ./...
- go vet ./...