### PR TITLE
[codex] Harden desktop atomic writes

### DIFF
--- a/clients/desktop/io.go
+++ b/clients/desktop/io.go
@@ -23,9 +23,42 @@ func writeFileAtomic(path string, data []byte, mode fs.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, mode); err != nil {
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		_ = tmp.Close()
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := renameReplace(tmpPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func renameReplace(src, dst string) error {
+	if err := os.Rename(src, dst); err != nil {
+		if os.IsExist(err) {
+			if removeErr := os.Remove(dst); removeErr == nil {
+				return os.Rename(src, dst)
+			}
+		}
+		return err
+	}
+	return nil
 }

--- a/clients/desktop/store.go
+++ b/clients/desktop/store.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -236,20 +235,13 @@ func (s *store) quarantineCorruptLocked(raw []byte) {
 }
 
 func (s *store) persistLocked() error {
-	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
-		return err
-	}
-	tmp := s.path + ".tmp"
 	cfg := s.data
 	cfg.Records = nil
 	raw, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(tmp, raw, 0o600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, s.path)
+	return writeFileAtomic(s.path, raw, 0o600)
 }
 
 func (s *store) close() error {

--- a/clients/desktop/store_test.go
+++ b/clients/desktop/store_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -23,6 +24,76 @@ func TestStoreLoadMissingConfigUsesDefaults(t *testing.T) {
 	}
 	if cfg.ServerTransport != serverTransportHTTP {
 		t.Fatalf("ServerTransport = %q, want http", cfg.ServerTransport)
+	}
+}
+
+func TestWriteFileAtomicIgnoresStaleFixedTempPath(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "proof.tdproof")
+	staleFixedTmp := path + ".tmp"
+	if err := os.Mkdir(staleFixedTmp, 0o755); err != nil {
+		t.Fatalf("Mkdir(stale tmp): %v", err)
+	}
+
+	if err := writeFileAtomic(path, []byte("proof"), 0o644); err != nil {
+		t.Fatalf("writeFileAtomic() error = %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != "proof" {
+		t.Fatalf("file content = %q, want proof", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(path) error = %v", err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("file mode = %v, want 0644", info.Mode().Perm())
+	}
+	staleInfo, err := os.Stat(staleFixedTmp)
+	if err != nil {
+		t.Fatalf("stale fixed temp path missing: %v", err)
+	}
+	if !staleInfo.IsDir() {
+		t.Fatalf("stale fixed temp path was modified; isDir=false")
+	}
+}
+
+func TestStorePersistIgnoresStaleFixedTempPath(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.json")
+	staleFixedTmp := path + ".tmp"
+	if err := os.Mkdir(staleFixedTmp, 0o755); err != nil {
+		t.Fatalf("Mkdir(stale tmp): %v", err)
+	}
+
+	store, err := newStore(path)
+	if err != nil {
+		t.Fatalf("newStore: %v", err)
+	}
+	defer store.close()
+	settings := defaultSettings()
+	settings.ServerURL = "http://127.0.0.1:9090"
+	if err := store.setSettings(settings); err != nil {
+		t.Fatalf("setSettings() error = %v", err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(config): %v", err)
+	}
+	if !bytes.Contains(raw, []byte(`"server_url": "http://127.0.0.1:9090"`)) {
+		t.Fatalf("persisted config missing server_url: %s", raw)
+	}
+	staleInfo, err := os.Stat(staleFixedTmp)
+	if err != nil {
+		t.Fatalf("stale fixed temp path missing: %v", err)
+	}
+	if !staleInfo.IsDir() {
+		t.Fatalf("stale fixed temp path was modified; isDir=false")
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace fixed .tmp desktop atomic writes with unique sibling temp files
- make desktop settings persistence reuse the shared atomic writer
- preserve requested export file modes and add stale temp path regression coverage

## Root cause
Desktop exports and settings persistence used deterministic path.tmp files. A stale temp path or concurrent write could block saves or leave confusing filesystem state for proof exports and local configuration.

## Validation
- cd clients/desktop && go test ./...
- cd clients/desktop && go vet ./...
- go test ./...
- go vet ./...