### PR TITLE
[codex] Harden CLI proof output paths

### DIFF
--- a/cmd/trustdb/commit_cmd.go
+++ b/cmd/trustdb/commit_cmd.go
@@ -162,7 +162,7 @@ func newCommitBatchCommand(rt *runtimeConfig) *cobra.Command {
 			}
 			outputs := make([]map[string]string, len(bundles))
 			for i := range bundles {
-				outPath := filepath.Join(outDir, bundles[i].RecordID+".tdproof")
+				outPath := filepath.Join(outDir, safeOutputFileName(bundles[i].RecordID)+".tdproof")
 				data, err := cborx.Marshal(bundles[i])
 				if err != nil {
 					return err

--- a/cmd/trustdb/commit_cmd_test.go
+++ b/cmd/trustdb/commit_cmd_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/ed25519"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -88,5 +89,32 @@ func TestResolveClientKeysRegistryFallback(t *testing.T) {
 	}
 	if resolver == nil {
 		t.Fatalf("resolveClientKeys() resolver = nil, want registry-backed resolver")
+	}
+}
+
+func TestSafeOutputFileNamePreventsTraversalAndCollisions(t *testing.T) {
+	t.Parallel()
+
+	outDir := t.TempDir()
+	name := safeOutputFileName("../outside")
+	if strings.ContainsAny(name, `/\`) {
+		t.Fatalf("safeOutputFileName() = %q, want a single path segment", name)
+	}
+	outPath := filepath.Join(outDir, name+".tdproof")
+	rel, err := filepath.Rel(outDir, outPath)
+	if err != nil {
+		t.Fatalf("Rel() error = %v", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		t.Fatalf("output path escapes out dir: outDir=%q outPath=%q rel=%q", outDir, outPath, rel)
+	}
+	if safeOutputFileName("rec/1") == safeOutputFileName("rec_2F1") {
+		t.Fatalf("safeOutputFileName() collides for slash and escaped-slash spelling")
+	}
+	if safeOutputFileName("") == safeOutputFileName("_") {
+		t.Fatalf("safeOutputFileName() collides for empty string and underscore")
+	}
+	if got := safeOutputFileName("rec-1_2.3"); got != "rec-1_2.3" {
+		t.Fatalf("safeOutputFileName() = %q, want plain safe name unchanged", got)
 	}
 }

--- a/cmd/trustdb/io.go
+++ b/cmd/trustdb/io.go
@@ -15,6 +15,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const encodedOutputNamePrefix = "~"
+
 type multiFlag []string
 
 func (m *multiFlag) String() string {
@@ -46,6 +48,26 @@ func ensureDir(path string) error {
 
 func joinPath(parts ...string) string {
 	return filepath.Join(parts...)
+}
+
+func safeOutputFileName(value string) string {
+	if isPlainOutputFileName(value) {
+		return value
+	}
+	return encodedOutputNamePrefix + base64.RawURLEncoding.EncodeToString([]byte(value))
+}
+
+func isPlainOutputFileName(value string) bool {
+	if value == "" || value == "." || value == ".." || strings.HasPrefix(value, ".") {
+		return false
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func readCBORFile(path string, v any) error {


### PR DESCRIPTION
## Summary
- encode commit-batch proof filenames with a collision-resistant safe path segment
- keep common safe record IDs unchanged
- add regression coverage for traversal and escaped-name collisions

## Root cause
commit-batch used record_id directly as the output filename under --out-dir. A record ID containing path separators or dot segments could write outside the intended proof directory or produce unexpected nested paths.

## Validation
- go test ./cmd/trustdb
- go test ./...
- go vet ./...