### PR TITLE
[codex] Harden CLI keygen output paths

### DIFF
--- a/cmd/trustdb/key_cmd.go
+++ b/cmd/trustdb/key_cmd.go
@@ -41,8 +41,9 @@ func newKeygenCommand(rt *runtimeConfig, hidden bool) *cobra.Command {
 			if err := ensureDir(outDir); err != nil {
 				return err
 			}
-			pubPath := joinPath(outDir, prefix+".pub")
-			privPath := joinPath(outDir, prefix+".key")
+			prefixName := safeOutputFileName(prefix)
+			pubPath := joinPath(outDir, prefixName+".pub")
+			privPath := joinPath(outDir, prefixName+".key")
 			if err := writeKey(pubPath, pub); err != nil {
 				return err
 			}

--- a/cmd/trustdb/root_test.go
+++ b/cmd/trustdb/root_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	trustconfig "github.com/ryan-wong-coder/trustdb/internal/config"
@@ -604,6 +605,51 @@ func TestKeyInspectCommand(t *testing.T) {
 	}
 	if got["kind"] != "public" || got["alg"] != "ed25519" || got["fingerprint"] == "" {
 		t.Fatalf("key inspect = %#v", got)
+	}
+}
+
+func TestKeygenPrefixCannotEscapeOutputDir(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	outDir := filepath.Join(tmp, "keys")
+	outsidePub := filepath.Join(tmp, "outside.pub")
+	outsideKey := filepath.Join(tmp, "outside.key")
+
+	var out, errOut bytes.Buffer
+	cmd := newRootCommand(&out, &errOut)
+	cmd.SetArgs([]string{"keygen", "--out", outDir, "--prefix", "../outside"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("keygen error = %v stderr=%s", err, errOut.String())
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("keygen output is not json: %q err=%v", out.String(), err)
+	}
+	for _, path := range []string{got["public_key"], got["private_key"]} {
+		if path == "" {
+			t.Fatalf("keygen output missing key path: %#v", got)
+		}
+		if strings.ContainsAny(filepath.Base(path), `/\`) {
+			t.Fatalf("key path base contains a path separator: %q", path)
+		}
+		rel, err := filepath.Rel(outDir, path)
+		if err != nil {
+			t.Fatalf("Rel() error = %v", err)
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+			t.Fatalf("key path escapes output dir: outDir=%q path=%q rel=%q", outDir, path, rel)
+		}
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected key file at %q: %v", path, err)
+		}
+	}
+	if _, err := os.Stat(outsidePub); !os.IsNotExist(err) {
+		t.Fatalf("keygen wrote outside public key %q: %v", outsidePub, err)
+	}
+	if _, err := os.Stat(outsideKey); !os.IsNotExist(err) {
+		t.Fatalf("keygen wrote outside private key %q: %v", outsideKey, err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- sanitize the `trustdb keygen --prefix` value before deriving `.pub` and `.key` paths
- add a CLI regression test proving traversal-style prefixes stay inside `--out`

## Why
`--prefix` is documented as a filename prefix but was joined directly into output paths. Values like `../outside` could escape the requested output directory and write key material elsewhere.

## Validation
- go test ./cmd/trustdb
- go test ./...
- go vet ./...