### PR TITLE
[codex] Harden CLI file writes

### DIFF
--- a/cmd/trustdb/claim_cmd.go
+++ b/cmd/trustdb/claim_cmd.go
@@ -100,7 +100,7 @@ func newClaimFileCommand(rt *runtimeConfig) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := os.WriteFile(outPath, data, 0o600); err != nil {
+			if err := writeFileAtomic(outPath, data, 0o600); err != nil {
 				return err
 			}
 			verified, err := claim.Verify(signed, priv.Public().(ed25519.PublicKey))

--- a/cmd/trustdb/commit_cmd.go
+++ b/cmd/trustdb/commit_cmd.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/ed25519"
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -73,7 +72,7 @@ func newCommitCommand(rt *runtimeConfig) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := os.WriteFile(outPath, data, 0o600); err != nil {
+			if err := writeFileAtomic(outPath, data, 0o600); err != nil {
 				return err
 			}
 			rt.logger.Info().
@@ -157,7 +156,7 @@ func newCommitBatchCommand(rt *runtimeConfig) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := os.MkdirAll(outDir, 0o755); err != nil {
+			if err := ensureDir(outDir); err != nil {
 				return err
 			}
 			outputs := make([]map[string]string, len(bundles))
@@ -167,7 +166,7 @@ func newCommitBatchCommand(rt *runtimeConfig) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				if err := os.WriteFile(outPath, data, 0o600); err != nil {
+				if err := writeFileAtomic(outPath, data, 0o600); err != nil {
 					return err
 				}
 				outputs[i] = map[string]string{

--- a/cmd/trustdb/config_cmd.go
+++ b/cmd/trustdb/config_cmd.go
@@ -35,7 +35,7 @@ func newConfigInitCommand(rt *runtimeConfig) *cobra.Command {
 					return trusterr.New(trusterr.CodeAlreadyExists, fmt.Sprintf("config file already exists: %s", outPath))
 				}
 			}
-			if err := os.WriteFile(outPath, []byte(trustconfig.DefaultYAML), 0o600); err != nil {
+			if err := writeFileAtomic(outPath, []byte(trustconfig.DefaultYAML), 0o600); err != nil {
 				return err
 			}
 			return rt.writeJSON(map[string]string{"config": outPath})

--- a/cmd/trustdb/io.go
+++ b/cmd/trustdb/io.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -83,10 +84,7 @@ func writeCBORFile(path string, v any) error {
 	if err != nil {
 		return err
 	}
-	if err := ensureDir(filepath.Dir(path)); err != nil {
-		return err
-	}
-	return os.WriteFile(path, data, 0o600)
+	return writeFileAtomic(path, data, 0o600)
 }
 
 func writeJSONFile(path string, v any) error {
@@ -95,10 +93,7 @@ func writeJSONFile(path string, v any) error {
 		return err
 	}
 	data = append(data, '\n')
-	if err := ensureDir(filepath.Dir(path)); err != nil {
-		return err
-	}
-	return os.WriteFile(path, data, 0o600)
+	return writeFileAtomic(path, data, 0o600)
 }
 
 func resolveExportFormat(format, outPath string) (string, error) {
@@ -144,7 +139,57 @@ func writeExportObject(rt *runtimeConfig, outPath, format string, v any) (string
 }
 
 func writeKey(path string, key []byte) error {
-	return os.WriteFile(path, []byte(base64.RawURLEncoding.EncodeToString(key)), 0o600)
+	return writeFileAtomic(path, []byte(base64.RawURLEncoding.EncodeToString(key)), 0o600)
+}
+
+func writeFileAtomic(path string, data []byte, mode fs.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := ensureDir(dir); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	closed := false
+	cleanup := true
+	defer func() {
+		if !closed {
+			_ = tmp.Close()
+		}
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		closed = true
+		return err
+	}
+	closed = true
+	if err := renameReplace(tmpPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func renameReplace(src, dst string) error {
+	if err := os.Rename(src, dst); err != nil {
+		if os.IsExist(err) {
+			if removeErr := os.Remove(dst); removeErr == nil {
+				return os.Rename(src, dst)
+			}
+		}
+		return err
+	}
+	return nil
 }
 
 func readPublicKey(path string) (ed25519.PublicKey, error) {

--- a/cmd/trustdb/io_test.go
+++ b/cmd/trustdb/io_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileAtomicReplacesFileAndCleansTemp(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "nested", "artifact.json")
+	if err := writeFileAtomic(path, []byte("old"), 0o600); err != nil {
+		t.Fatalf("writeFileAtomic(old) error = %v", err)
+	}
+	if err := writeFileAtomic(path, []byte("new"), 0o600); err != nil {
+		t.Fatalf("writeFileAtomic(new) error = %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("file content = %q, want new", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("file mode = %v, want 0600", info.Mode().Perm())
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp"))
+	if err != nil {
+		t.Fatalf("Glob() error = %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary files were not cleaned up: %v", matches)
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared atomic file writer for the TrustDB CLI
- route JSON, CBOR, key, claim, proof, and config outputs through temp-file-plus-rename writes
- cover replacement semantics, file mode, parent directory creation, and temp cleanup with a regression test

## Why
Several CLI outputs used direct `os.WriteFile`. If the process was interrupted or a filesystem error occurred mid-write, operators could be left with truncated key, claim, proof, config, or report files that looked like final artifacts.

## Validation
- go test ./cmd/trustdb
- go test ./...
- go vet ./...