### PR TITLE
[codex] Harden batch fallback validation

### DIFF
--- a/internal/batch/service.go
+++ b/internal/batch/service.go
@@ -533,6 +533,9 @@ func (s *Service) persistBatch(ctx context.Context, batchID string, closedAt tim
 }
 
 func (s *Service) writeBundlesAndRoot(ctx context.Context, batchID string, bundles []model.ProofBundle) (model.BatchRoot, error) {
+	if len(bundles) == 0 {
+		return model.BatchRoot{}, trusterr.New(trusterr.CodeInternal, "commit batch returned no proof bundles")
+	}
 	root := rootFromBundles(batchID, bundles)
 	if writer, ok := s.store.(proofstore.BatchArtifactWriter); ok {
 		if err := writer.PutBatchArtifacts(ctx, bundles, root); err != nil {
@@ -596,11 +599,11 @@ func rootFromBundles(batchID string, bundles []model.ProofBundle) model.BatchRoo
 	r := model.BatchRoot{
 		SchemaVersion: model.SchemaBatchRoot,
 		BatchID:       batchID,
-		BatchRoot:     append([]byte(nil), bundles[0].CommittedReceipt.BatchRoot...),
 		TreeSize:      uint64(len(bundles)),
-		ClosedAtUnixN: bundles[0].CommittedReceipt.ClosedAtUnixN,
 	}
 	if len(bundles) > 0 {
+		r.BatchRoot = append([]byte(nil), bundles[0].CommittedReceipt.BatchRoot...)
+		r.ClosedAtUnixN = bundles[0].CommittedReceipt.ClosedAtUnixN
 		r.NodeID = bundles[0].NodeID
 		r.LogID = bundles[0].LogID
 	}
@@ -614,6 +617,9 @@ func (s *Service) planBatchIndexes(batchID string, closedAt time.Time, signed []
 	bundles, err := s.engine.CommitBatch(batchID, closedAt, signed, records, accepted)
 	if err != nil {
 		return model.BatchRoot{}, nil, err
+	}
+	if len(bundles) != len(records) {
+		return model.BatchRoot{}, nil, trusterr.New(trusterr.CodeInternal, "commit batch returned inconsistent proof count")
 	}
 	indexes := make([]model.RecordIndex, len(bundles))
 	for i := range bundles {

--- a/internal/batch/service_test.go
+++ b/internal/batch/service_test.go
@@ -316,6 +316,34 @@ func TestServiceAsyncProofModePublishesIndexBeforeBundle(t *testing.T) {
 	}
 }
 
+func TestServiceNonInlineFallbackRejectsInconsistentProofCount(t *testing.T) {
+	t.Parallel()
+
+	store := proofstore.LocalStore{Root: t.TempDir()}
+	svc := New(emptyBundleEngine{}, store, Options{
+		QueueSize:  4,
+		MaxRecords: 1,
+		MaxDelay:   time.Hour,
+		ProofMode:  ProofModeAsync,
+	}, nil)
+	defer svc.Shutdown(context.Background())
+
+	if err := svc.Enqueue(context.Background(), signed("bad-count"), recordWithWAL("bad-count", 33), accepted("bad-count")); err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+
+	err := waitForLastError(t, svc)
+	if trusterr.CodeOf(err) != trusterr.CodeInternal {
+		t.Fatalf("LastError() code = %s err=%v, want internal", trusterr.CodeOf(err), err)
+	}
+	if !strings.Contains(err.Error(), "inconsistent proof count") {
+		t.Fatalf("LastError() = %v, want inconsistent proof count", err)
+	}
+	if _, ok, err := store.GetRecordIndex(context.Background(), "bad-count"); err != nil || ok {
+		t.Fatalf("GetRecordIndex() ok=%v err=%v, want no index after failed plan", ok, err)
+	}
+}
+
 func TestServiceOnDemandProofModeMaterializesOnce(t *testing.T) {
 	t.Parallel()
 
@@ -522,6 +550,20 @@ func waitForProof(t *testing.T, svc *Service, recordID string) model.ProofBundle
 	return model.ProofBundle{}
 }
 
+func waitForLastError(t *testing.T, svc *Service) error {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := svc.LastError(); err != nil {
+			return err
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	err := svc.LastError()
+	t.Fatalf("LastError() after wait = %v, want non-nil", err)
+	return nil
+}
+
 type fakeEngine struct{}
 
 func (fakeEngine) CommitBatch(batchID string, closedAt time.Time, signed []model.SignedClaim, records []model.ServerRecord, accepted []model.AcceptedReceipt) ([]model.ProofBundle, error) {
@@ -592,6 +634,12 @@ func (e blockingEngine) CommitBatch(batchID string, closedAt time.Time, signed [
 	}
 	<-e.block
 	return fakeEngine{}.CommitBatch(batchID, closedAt, signed, records, accepted)
+}
+
+type emptyBundleEngine struct{}
+
+func (emptyBundleEngine) CommitBatch(string, time.Time, []model.SignedClaim, []model.ServerRecord, []model.AcceptedReceipt) ([]model.ProofBundle, error) {
+	return nil, nil
 }
 
 type blockingMaterializeEngine struct {


### PR DESCRIPTION
## Summary
- validate fallback `CommitBatch` proof counts before deriving non-inline indexes
- guard bundle/root writes against empty proof bundle slices
- add a regression test proving bad fallback output becomes `LastError` instead of a batch worker panic

## Why
In async/on-demand proof modes, a store engine that only implements `CommitBatch` is used as a fallback for record index planning. If that engine returned an inconsistent proof slice, the service could reach `rootFromBundles` and panic the batch worker goroutine instead of surfacing a structured error.

## Validation
- go test ./internal/batch
- go test ./...
- go vet ./...