### PR TITLE
[codex] Harden SDK HTTP nil contexts

### DIFF
--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -282,6 +282,31 @@ func TestClientOperationalEndpoints(t *testing.T) {
 	}
 }
 
+func TestHTTPTransportNilContextUsesDefaultTimeout(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		writeJSONForTest(t, w, http.StatusOK, map[string]bool{"ok": true})
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("CheckHealth(nil) panicked: %v", recovered)
+		}
+	}()
+	if status := client.CheckHealth(nil); !status.OK || status.ServerURL != server.URL {
+		t.Fatalf("health status = %+v", status)
+	}
+}
+
 func TestClientMetricsRejectsOversizedResponse(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/http_transport.go
+++ b/sdk/http_transport.go
@@ -278,7 +278,9 @@ func (t *httpTransport) doJSON(ctx context.Context, method, path string, query u
 
 func (t *httpTransport) doRaw(ctx context.Context, method, path string, query url.Values, body io.Reader, contentType string, limit int64) ([]byte, error) {
 	endpoint := t.endpoint(path, query)
-	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	reqCtx, cancel := contextWithDefaultTimeout(ctx)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, method, endpoint, body)
 	if err != nil {
 		return nil, &Error{Op: method, URL: endpoint, Err: err}
 	}


### PR DESCRIPTION
## Summary

- Harden the SDK HTTP transport so nil contexts are wrapped with the same default timeout behavior used by gRPC calls.
- Add a regression test covering `CheckHealth(nil)` to prevent panics from returning.

## Root cause

`http.NewRequestWithContext` panics when called with a nil context. The HTTP transport passed caller contexts through directly, unlike the gRPC transport, which normalized nil and deadline-less contexts.

## Validation

- `go test ./sdk`
- `go test ./...`
- `go vet ./...`
