### PR TITLE
[codex] Harden load-balanced SDK nil contexts

### DIFF
--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -127,6 +127,48 @@ func TestLoadBalancedClientFailsOver(t *testing.T) {
 	}
 }
 
+func TestLoadBalancedClientNilContextDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/claims" {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		writeJSONForTest(t, w, http.StatusAccepted, submitClaimEnvelope{
+			RecordID:   "tr1record",
+			Status:     "accepted",
+			ProofLevel: ProofLevelL2,
+			ServerRecord: ServerRecord{
+				SchemaVersion: model.SchemaServerRecord,
+				RecordID:      "tr1record",
+			},
+			AcceptedReceipt: AcceptedReceipt{
+				SchemaVersion: model.SchemaAcceptedReceipt,
+				RecordID:      "tr1record",
+				Status:        "accepted",
+			},
+		})
+	}))
+	defer server.Close()
+
+	client, err := NewLoadBalancedClient([]string{server.URL}, LoadBalanceOptions{Mode: LoadBalanceFailover})
+	if err != nil {
+		t.Fatalf("NewLoadBalancedClient: %v", err)
+	}
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("SubmitSignedClaim(nil) panicked: %v", recovered)
+		}
+	}()
+	result, err := client.SubmitSignedClaim(nil, SignedClaim{SchemaVersion: model.SchemaSignedClaim})
+	if err != nil {
+		t.Fatalf("SubmitSignedClaim: %v", err)
+	}
+	if result.RecordID != "tr1record" {
+		t.Fatalf("result = %+v", result)
+	}
+}
+
 func TestClientListRecordsEncodesQuery(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/load_balance.go
+++ b/sdk/load_balance.go
@@ -87,6 +87,9 @@ func (t *loadBalancedTransport) order() []Transport {
 func tryEndpoints[T any](ctx context.Context, t *loadBalancedTransport, op string, fn func(context.Context, Transport) (T, error)) (T, error) {
 	var zero T
 	var errs error
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	for _, transport := range t.order() {
 		if err := ctx.Err(); err != nil {
 			return zero, err


### PR DESCRIPTION
## Summary

- Normalize nil contexts before load-balanced SDK retry loops inspect `ctx.Err()`.
- Add a regression test for `SubmitSignedClaim(nil)` through `NewLoadBalancedClient`.

## Root cause

The load-balanced transport checked `ctx.Err()` before invoking the selected endpoint. A nil caller context therefore panicked in the retry layer, even though the underlying transports can safely apply default timeout behavior.

## Validation

- `go test ./sdk`
- `go test ./...`
- `go vet ./...`
