### PR TITLE
[codex] Bound proof file reads

### DIFF
--- a/clients/desktop/verify.go
+++ b/clients/desktop/verify.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -248,7 +249,7 @@ func (a *App) resolveServerPub(override string) (ed25519.PublicKey, error) {
 }
 
 func readProofBundleFile(path string, out *model.ProofBundle) error {
-	data, err := os.ReadFile(path)
+	data, err := readCBORFileLimit(path, cborx.DefaultMaxBytes)
 	if err != nil {
 		return fmt.Errorf("read proof: %w", err)
 	}
@@ -262,7 +263,7 @@ func readProofBundleFile(path string, out *model.ProofBundle) error {
 }
 
 func readSingleProofFile(path string, out *model.SingleProof) error {
-	data, err := os.ReadFile(path)
+	data, err := readCBORFileLimit(path, sproof.MaxBytes)
 	if err != nil {
 		return fmt.Errorf("read single proof: %w", err)
 	}
@@ -278,7 +279,7 @@ func readSingleProofFile(path string, out *model.SingleProof) error {
 	return nil
 }
 func readGlobalProofFile(path string, out *model.GlobalLogProof) error {
-	data, err := os.ReadFile(path)
+	data, err := readCBORFileLimit(path, cborx.DefaultMaxBytes)
 	if err != nil {
 		return fmt.Errorf("read global proof: %w", err)
 	}
@@ -292,7 +293,7 @@ func readGlobalProofFile(path string, out *model.GlobalLogProof) error {
 }
 
 func readAnchorResultFile(path string, out *model.STHAnchorResult) error {
-	data, err := os.ReadFile(path)
+	data, err := readCBORFileLimit(path, cborx.DefaultMaxBytes)
 	if err != nil {
 		return fmt.Errorf("read anchor: %w", err)
 	}
@@ -303,6 +304,25 @@ func readAnchorResultFile(path string, out *model.STHAnchorResult) error {
 		return schemaMismatchError("anchor", path, model.SchemaSTHAnchorResult, out.SchemaVersion)
 	}
 	return nil
+}
+
+func readCBORFileLimit(path string, maxBytes int) ([]byte, error) {
+	if maxBytes <= 0 {
+		return nil, fmt.Errorf("max bytes must be positive")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, int64(maxBytes)+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxBytes {
+		return nil, fmt.Errorf("payload too large: %d > %d", len(data), maxBytes)
+	}
+	return data, nil
 }
 
 func schemaMismatchError(kind, path, want, got string) error {

--- a/clients/desktop/verify_test.go
+++ b/clients/desktop/verify_test.go
@@ -110,6 +110,20 @@ func TestReadProofBundleFileExplainsSingleProofMixup(t *testing.T) {
 	}
 }
 
+func TestReadProofBundleFileRejectsOversizedInput(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "oversized.tdproof")
+	if err := os.WriteFile(path, make([]byte, cborx.DefaultMaxBytes+1), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	var bundle model.ProofBundle
+	err := readProofBundleFile(path, &bundle)
+	if err == nil || !strings.Contains(err.Error(), "payload too large") {
+		t.Fatalf("readProofBundleFile() error = %v, want payload too large", err)
+	}
+}
+
 func writeCBORForTest(t *testing.T, path string, v any) {
 	t.Helper()
 	data, err := cborx.Marshal(v)

--- a/internal/sproof/sproof.go
+++ b/internal/sproof/sproof.go
@@ -141,12 +141,16 @@ func Unmarshal(data []byte) (model.SingleProof, error) {
 }
 
 func ReadFile(path string) (model.SingleProof, error) {
-	data, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return model.SingleProof{}, err
 	}
-	proof, err := Unmarshal(data)
-	if err != nil {
+	defer f.Close()
+	var proof model.SingleProof
+	if err := cborx.DecodeReaderLimit(f, &proof, MaxBytes); err != nil {
+		return model.SingleProof{}, fmt.Errorf("read sproof %s: %w", filepath.Base(path), err)
+	}
+	if err := Validate(proof); err != nil {
 		return model.SingleProof{}, fmt.Errorf("read sproof %s: %w", filepath.Base(path), err)
 	}
 	return proof, nil

--- a/internal/sproof/sproof_test.go
+++ b/internal/sproof/sproof_test.go
@@ -111,6 +111,18 @@ func TestSProofV1L3Vector(t *testing.T) {
 	}
 }
 
+func TestReadFileRejectsOversizedSingleProof(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "oversized.sproof")
+	if err := os.WriteFile(path, make([]byte, MaxBytes+1), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := ReadFile(path); err == nil {
+		t.Fatal("ReadFile() error = nil, want oversized invalid proof rejection")
+	}
+}
+
 func vectorProof() model.SingleProof {
 	return model.SingleProof{
 		SchemaVersion:   model.SchemaSingleProof,


### PR DESCRIPTION
## Summary

- Decode `.sproof` files through the bounded CBOR reader instead of reading the whole file into memory first.
- Add bounded reads for desktop local proof, global proof, anchor, and single-proof inputs before CBOR type detection.
- Add oversized-input regression coverage for core `.sproof` and desktop proof-bundle reads.

## Root cause

Proof-file readers applied CBOR size limits only after `os.ReadFile` loaded the entire selected file. A very large local file could therefore consume memory before the existing decode limits had a chance to reject it.

## Validation

- `go test ./internal/sproof ./clients/desktop`
- `go test ./...`
- `go vet ./...`
