### PR TITLE
[codex] Write single proofs atomically

### DIFF
--- a/internal/sproof/sproof.go
+++ b/internal/sproof/sproof.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -161,10 +162,56 @@ func WriteFile(path string, proof model.SingleProof) error {
 	if err != nil {
 		return err
 	}
+	return writeFileAtomic(path, data, 0o600)
+}
+
+func writeFileAtomic(path string, data []byte, mode fs.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o600)
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		_ = tmp.Close()
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if info, err := os.Stat(path); err == nil && info.IsDir() {
+		return fmt.Errorf("%s is a directory", path)
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := renameReplace(tmpPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func renameReplace(src, dst string) error {
+	if err := os.Rename(src, dst); err != nil {
+		if os.IsExist(err) {
+			if removeErr := os.Remove(dst); removeErr == nil {
+				return os.Rename(src, dst)
+			}
+		}
+		return err
+	}
+	return nil
 }
 
 func Digest(proof model.SingleProof) ([32]byte, error) {

--- a/internal/sproof/sproof_test.go
+++ b/internal/sproof/sproof_test.go
@@ -123,6 +123,61 @@ func TestReadFileRejectsOversizedSingleProof(t *testing.T) {
 	}
 }
 
+func TestWriteFileRoundTripUsesPrivateMode(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "proof.sproof")
+	proof := vectorProof()
+	if err := WriteFile(path, proof); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	got, err := ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	equal, err := EqualEncoded(got, proof)
+	if err != nil {
+		t.Fatalf("EqualEncoded() error = %v", err)
+	}
+	if !equal {
+		t.Fatalf("decoded proof = %+v, want vector proof", got)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("mode = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestWriteFileCleansTemporaryFileOnFailure(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "existing-dir")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	if err := WriteFile(target, vectorProof()); err == nil {
+		t.Fatal("WriteFile() error = nil, want failure when target is a directory")
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("Stat(target) error = %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("target was replaced; mode=%s", info.Mode())
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, ".existing-dir.*.tmp"))
+	if err != nil {
+		t.Fatalf("Glob() error = %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary files left behind: %v", matches)
+	}
+}
+
 func vectorProof() model.SingleProof {
 	return model.SingleProof{
 		SchemaVersion:   model.SchemaSingleProof,


### PR DESCRIPTION
## Summary

- Write `.sproof` single-proof files through a sibling temporary file and rename into place.
- Preserve private 0600 permissions and clean temporary files on failure.
- Explicitly reject directory targets so atomic rename cannot replace an existing directory on platforms that allow that edge case.

## Root cause

The core single-proof writer used `os.WriteFile` directly, unlike the CLI and desktop export paths. An interrupted export could leave a partial proof file, and the first atomic-write draft exposed a platform-specific directory replacement edge case that now has regression coverage.

## Validation

- `go test ./internal/sproof ./sdk ./cmd/trustdb`
- `go test ./...`
- `go vet ./...`
