### PR TITLE
[codex] Harden atomic writes against directory targets

### DIFF
--- a/clients/desktop/io.go
+++ b/clients/desktop/io.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -52,6 +53,9 @@ func writeFileAtomic(path string, data []byte, mode fs.FileMode) error {
 }
 
 func renameReplace(src, dst string) error {
+	if err := rejectDirectoryTarget(dst); err != nil {
+		return err
+	}
 	if err := os.Rename(src, dst); err != nil {
 		if os.IsExist(err) {
 			if removeErr := os.Remove(dst); removeErr == nil {
@@ -61,4 +65,18 @@ func renameReplace(src, dst string) error {
 		return err
 	}
 	return nil
+}
+
+func rejectDirectoryTarget(path string) error {
+	info, err := os.Stat(path)
+	if err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("%s is a directory", path)
+		}
+		return nil
+	}
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
 }

--- a/clients/desktop/store_test.go
+++ b/clients/desktop/store_test.go
@@ -62,6 +62,33 @@ func TestWriteFileAtomicIgnoresStaleFixedTempPath(t *testing.T) {
 	}
 }
 
+func TestWriteFileAtomicRejectsDirectoryTarget(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "proof.tdproof")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("Mkdir(target) error = %v", err)
+	}
+
+	if err := writeFileAtomic(path, []byte("proof"), 0o644); err == nil {
+		t.Fatalf("writeFileAtomic() error = nil, want directory target error")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(target) error = %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("target directory was replaced")
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp"))
+	if err != nil {
+		t.Fatalf("Glob() error = %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary files were not cleaned up: %v", matches)
+	}
+}
+
 func TestStorePersistIgnoresStaleFixedTempPath(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/trustdb/io.go
+++ b/cmd/trustdb/io.go
@@ -181,6 +181,9 @@ func writeFileAtomic(path string, data []byte, mode fs.FileMode) error {
 }
 
 func renameReplace(src, dst string) error {
+	if err := rejectDirectoryTarget(dst); err != nil {
+		return err
+	}
 	if err := os.Rename(src, dst); err != nil {
 		if os.IsExist(err) {
 			if removeErr := os.Remove(dst); removeErr == nil {
@@ -190,6 +193,20 @@ func renameReplace(src, dst string) error {
 		return err
 	}
 	return nil
+}
+
+func rejectDirectoryTarget(path string) error {
+	info, err := os.Stat(path)
+	if err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("%s is a directory", path)
+		}
+		return nil
+	}
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
 }
 
 func readPublicKey(path string) (ed25519.PublicKey, error) {

--- a/cmd/trustdb/io_test.go
+++ b/cmd/trustdb/io_test.go
@@ -39,3 +39,30 @@ func TestWriteFileAtomicReplacesFileAndCleansTemp(t *testing.T) {
 		t.Fatalf("temporary files were not cleaned up: %v", matches)
 	}
 }
+
+func TestWriteFileAtomicRejectsDirectoryTarget(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "artifact.json")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("Mkdir(target) error = %v", err)
+	}
+
+	if err := writeFileAtomic(path, []byte("new"), 0o600); err == nil {
+		t.Fatalf("writeFileAtomic() error = nil, want directory target error")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(target) error = %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("target directory was replaced")
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp"))
+	if err != nil {
+		t.Fatalf("Glob() error = %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary files were not cleaned up: %v", matches)
+	}
+}

--- a/internal/adminweb/adminweb_test.go
+++ b/internal/adminweb/adminweb_test.go
@@ -22,6 +22,33 @@ func testLogger() zerolog.Logger {
 	return zerolog.New(io.Discard).Level(zerolog.Disabled)
 }
 
+func TestWriteConfigAtomicRejectsDirectoryTarget(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("Mkdir(target) error = %v", err)
+	}
+
+	if err := writeConfigAtomic(path, []byte("server:\n")); err == nil {
+		t.Fatalf("writeConfigAtomic() error = nil, want directory target error")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(target) error = %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("target directory was replaced")
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp"))
+	if err != nil {
+		t.Fatalf("Glob() error = %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary files were not cleaned up: %v", matches)
+	}
+}
+
 func TestNewRequiresIndexHTML(t *testing.T) {
 	t.Parallel()
 	tmp := t.TempDir()

--- a/internal/adminweb/handler.go
+++ b/internal/adminweb/handler.go
@@ -312,6 +312,9 @@ func writeConfigAtomic(path string, data []byte) error {
 }
 
 func renameReplace(src, dst string) error {
+	if err := rejectDirectoryTarget(dst); err != nil {
+		return err
+	}
 	if err := os.Rename(src, dst); err != nil {
 		if os.IsExist(err) {
 			if removeErr := os.Remove(dst); removeErr == nil {
@@ -321,6 +324,20 @@ func renameReplace(src, dst string) error {
 		return err
 	}
 	return nil
+}
+
+func rejectDirectoryTarget(path string) error {
+	info, err := os.Stat(path)
+	if err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("%s is a directory", path)
+		}
+		return nil
+	}
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
 }
 
 func (h *handler) getOverlays(w http.ResponseWriter, r *http.Request) {

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -895,6 +895,9 @@ func writeFileAtomic(path string, data []byte) error {
 }
 
 func renameReplace(src, dst string) error {
+	if err := rejectDirectoryTarget(dst); err != nil {
+		return err
+	}
 	if err := os.Rename(src, dst); err != nil {
 		if os.IsExist(err) {
 			if removeErr := os.Remove(dst); removeErr == nil {
@@ -904,6 +907,20 @@ func renameReplace(src, dst string) error {
 		return err
 	}
 	return nil
+}
+
+func rejectDirectoryTarget(path string) error {
+	info, err := os.Stat(path)
+	if err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("%s is a directory", path)
+		}
+		return nil
+	}
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
 }
 
 func normaliseCompression(value string) string {

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -162,6 +162,63 @@ func TestBackupCreateVerifyRestoreRoundTrip(t *testing.T) {
 	}
 }
 
+func TestCreateRejectsDirectoryTarget(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	store := proofstore.LocalStore{Root: filepath.Join(t.TempDir(), "src")}
+	path := filepath.Join(t.TempDir(), "trustdb.tdbackup")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("Mkdir(target) error = %v", err)
+	}
+
+	if _, err := Create(ctx, store, path, Options{}); err == nil {
+		t.Fatalf("Create() error = nil, want directory target error")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(target) error = %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("target directory was replaced")
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp"))
+	if err != nil {
+		t.Fatalf("Glob() error = %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary files were not cleaned up: %v", matches)
+	}
+}
+
+func TestWriteRestoreCheckpointRejectsDirectoryTarget(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "restore-checkpoint.json")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("Mkdir(target) error = %v", err)
+	}
+
+	err := writeRestoreCheckpoint(path, RestoreCheckpoint{SchemaVersion: SchemaRestoreCheckpoint})
+	if err == nil {
+		t.Fatalf("writeRestoreCheckpoint() error = nil, want directory target error")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(target) error = %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("target directory was replaced")
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp"))
+	if err != nil {
+		t.Fatalf("Glob() error = %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary files were not cleaned up: %v", matches)
+	}
+}
+
 func TestCreateDoesNotReplaceTargetOnFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/objectstore/local.go
+++ b/internal/objectstore/local.go
@@ -61,7 +61,10 @@ func (s LocalStore) Put(ctx context.Context, r io.Reader) (PutResult, error) {
 	if err := os.MkdirAll(filepath.Dir(finalPath), 0o755); err != nil {
 		return PutResult{}, err
 	}
-	if _, err := os.Stat(finalPath); err == nil {
+	if info, err := os.Stat(finalPath); err == nil {
+		if info.IsDir() {
+			return PutResult{}, fmt.Errorf("objectstore: object path %s is a directory", finalPath)
+		}
 		return PutResult{
 			HashAlg:       model.DefaultHashAlg,
 			ContentHash:   sum,
@@ -69,6 +72,8 @@ func (s LocalStore) Put(ctx context.Context, r io.Reader) (PutResult, error) {
 			URI:           "trustdb-local://" + model.DefaultHashAlg + "/" + hexSum,
 			Path:          finalPath,
 		}, nil
+	} else if !os.IsNotExist(err) {
+		return PutResult{}, err
 	}
 	if err := os.Rename(tmpPath, finalPath); err != nil {
 		return PutResult{}, err

--- a/internal/objectstore/local_test.go
+++ b/internal/objectstore/local_test.go
@@ -1,0 +1,42 @@
+package objectstore
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocalStorePutRejectsDirectoryObjectTarget(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte("object store payload")
+	sum := sha256.Sum256(raw)
+	hexSum := hex.EncodeToString(sum[:])
+	store := LocalStore{Root: t.TempDir()}
+	target := store.pathForHex(hexSum)
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("MkdirAll(target) error = %v", err)
+	}
+
+	if _, err := store.Put(context.Background(), bytes.NewReader(raw)); err == nil {
+		t.Fatalf("Put() error = nil, want directory target error")
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("Stat(target) error = %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("target directory was replaced")
+	}
+	matches, err := filepath.Glob(filepath.Join(store.Root, "put-*.tmp"))
+	if err != nil {
+		t.Fatalf("Glob() error = %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary files were not cleaned up: %v", matches)
+	}
+}

--- a/internal/proofstore/local.go
+++ b/internal/proofstore/local.go
@@ -1911,6 +1911,9 @@ func writeCBORAtomic(path string, value any) error {
 	if err := tmp.Close(); err != nil {
 		return err
 	}
+	if err := rejectDirectoryTarget(path); err != nil {
+		return err
+	}
 	if err := os.Rename(tmpPath, path); err != nil {
 		if os.IsExist(err) {
 			if removeErr := os.Remove(path); removeErr == nil {
@@ -1924,6 +1927,20 @@ func writeCBORAtomic(path string, value any) error {
 	}
 	cleanup = false
 	return nil
+}
+
+func rejectDirectoryTarget(path string) error {
+	info, err := os.Stat(path)
+	if err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("%s is a directory", path)
+		}
+		return nil
+	}
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
 }
 
 func readFileWithFallback(primary string, fallbacks ...string) ([]byte, error) {

--- a/internal/proofstore/local_test.go
+++ b/internal/proofstore/local_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ryan-wong-coder/trustdb/internal/model"
@@ -27,6 +28,34 @@ func TestLocalStoreBundleRoundTrip(t *testing.T) {
 	}
 	if got.RecordID != bundle.RecordID || got.SchemaVersion != model.SchemaProofBundle {
 		t.Fatalf("GetBundle() = %+v", got)
+	}
+}
+
+func TestWriteCBORAtomicRejectsDirectoryTarget(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "bundle.tdproof")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("Mkdir(target) error = %v", err)
+	}
+
+	err := writeCBORAtomic(path, model.ProofBundle{RecordID: "record-1"})
+	if err == nil {
+		t.Fatalf("writeCBORAtomic() error = nil, want directory target error")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat(target) error = %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("target directory was replaced")
+	}
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp"))
+	if err != nil {
+		t.Fatalf("Glob() error = %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary files were not cleaned up: %v", matches)
 	}
 }
 

--- a/internal/sproof/sproof.go
+++ b/internal/sproof/sproof.go
@@ -190,11 +190,6 @@ func writeFileAtomic(path string, data []byte, mode fs.FileMode) error {
 	if err := tmp.Close(); err != nil {
 		return err
 	}
-	if info, err := os.Stat(path); err == nil && info.IsDir() {
-		return fmt.Errorf("%s is a directory", path)
-	} else if err != nil && !os.IsNotExist(err) {
-		return err
-	}
 	if err := renameReplace(tmpPath, path); err != nil {
 		return err
 	}
@@ -203,6 +198,9 @@ func writeFileAtomic(path string, data []byte, mode fs.FileMode) error {
 }
 
 func renameReplace(src, dst string) error {
+	if err := rejectDirectoryTarget(dst); err != nil {
+		return err
+	}
 	if err := os.Rename(src, dst); err != nil {
 		if os.IsExist(err) {
 			if removeErr := os.Remove(dst); removeErr == nil {
@@ -212,6 +210,20 @@ func renameReplace(src, dst string) error {
 		return err
 	}
 	return nil
+}
+
+func rejectDirectoryTarget(path string) error {
+	info, err := os.Stat(path)
+	if err == nil {
+		if info.IsDir() {
+			return fmt.Errorf("%s is a directory", path)
+		}
+		return nil
+	}
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
 }
 
 func Digest(proof model.SingleProof) ([32]byte, error) {


### PR DESCRIPTION
## Summary
- Reject existing directory targets before atomic rename in CLI, desktop, admin config, backup, proofstore, and sproof file writes
- Return an explicit objectstore error when a content-addressed object path is a directory
- Add regression tests that verify directories are preserved and temp files are cleaned up

## Root cause
On macOS, renaming a temp file over an empty directory target can replace that directory with the file. Several atomic write helpers relied on os.Rename/fallback replacement without first rejecting directory targets.

## Validation
- go test ./cmd/trustdb ./clients/desktop ./internal/adminweb ./internal/backup ./internal/proofstore ./internal/objectstore ./internal/sproof
- go test ./...
- go vet ./...