### PR TITLE
[codex] Validate backup restore checkpoints

### DIFF
--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -30,6 +30,7 @@ const SchemaManifest = "trustdb.backup.v2"
 const SchemaRestoreCheckpoint = "trustdb.backup-restore-checkpoint.v1"
 const scanPageSize = 1024
 const maxRestoreEntryBytes int64 = 128 << 20
+const maxRestoreCheckpointBytes int64 = 1 << 20
 
 const (
 	paxBackupID = "trustdb.backup_id"
@@ -392,10 +393,17 @@ func RestoreWithOptions(ctx context.Context, store proofstore.Store, path string
 	}
 	report := Manifest{SchemaVersion: SchemaManifest}
 	checkpointPath := opts.CheckpointPath
+	var restoreCP RestoreCheckpoint
 	if opts.Resume && checkpointPath == "" {
 		checkpointPath = path + ".restore-checkpoint.json"
 	}
-	restoreCP, _ := readRestoreCheckpoint(checkpointPath)
+	if opts.Resume {
+		var err error
+		restoreCP, err = readRestoreCheckpoint(checkpointPath)
+		if err != nil {
+			return Manifest{}, trusterr.Wrap(trusterr.CodeDataLoss, "read restore checkpoint", err)
+		}
+	}
 	err := readArchiveStream(path, func(entry archiveEntry) error {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -816,12 +824,20 @@ func readRestoreCheckpoint(path string) (RestoreCheckpoint, error) {
 	if path == "" {
 		return RestoreCheckpoint{}, nil
 	}
-	data, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return RestoreCheckpoint{}, nil
 		}
 		return RestoreCheckpoint{}, err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, maxRestoreCheckpointBytes+1))
+	if err != nil {
+		return RestoreCheckpoint{}, err
+	}
+	if int64(len(data)) > maxRestoreCheckpointBytes {
+		return RestoreCheckpoint{}, fmt.Errorf("backup restore checkpoint too large: %d bytes", len(data))
 	}
 	var cp RestoreCheckpoint
 	if err := json.Unmarshal(data, &cp); err != nil {

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -219,6 +219,43 @@ func TestWriteRestoreCheckpointRejectsDirectoryTarget(t *testing.T) {
 	}
 }
 
+func TestRestoreRejectsInvalidResumeCheckpoint(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	src := proofstore.LocalStore{Root: filepath.Join(t.TempDir(), "src")}
+	backupPath := filepath.Join(t.TempDir(), "trustdb.tdbackup")
+	if _, err := Create(ctx, src, backupPath, Options{Compression: "none"}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	checkpointPath := filepath.Join(t.TempDir(), "restore.checkpoint.json")
+	if err := os.WriteFile(checkpointPath, []byte("{not-json"), 0o600); err != nil {
+		t.Fatalf("WriteFile(checkpoint) error = %v", err)
+	}
+
+	dst := proofstore.LocalStore{Root: filepath.Join(t.TempDir(), "dst")}
+	_, err := RestoreWithOptions(ctx, dst, backupPath, RestoreOptions{
+		Resume:         true,
+		CheckpointPath: checkpointPath,
+	})
+	if err == nil {
+		t.Fatalf("RestoreWithOptions() error = nil, want invalid checkpoint error")
+	}
+}
+
+func TestReadRestoreCheckpointRejectsOversizedFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "restore.checkpoint.json")
+	if err := os.WriteFile(path, bytes.Repeat([]byte("x"), int(maxRestoreCheckpointBytes)+1), 0o600); err != nil {
+		t.Fatalf("WriteFile(checkpoint) error = %v", err)
+	}
+
+	if _, err := readRestoreCheckpoint(path); err == nil {
+		t.Fatalf("readRestoreCheckpoint() error = nil, want oversized checkpoint error")
+	}
+}
+
 func TestCreateDoesNotReplaceTargetOnFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- read restore checkpoints only when resume mode is enabled
- fail restore when a resume checkpoint is unreadable or invalid instead of silently ignoring it
- cap restore checkpoint reads at 1 MiB to avoid loading oversized local state files

## Root cause
RestoreWithOptions discarded errors from readRestoreCheckpoint. A corrupt or oversized checkpoint could be ignored, causing a resume restore to restart from the beginning and hiding local checkpoint corruption.

## Validation
- go test ./internal/backup
- go test ./...
- go vet ./...