### PR TITLE
docs: add official project homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 ![CI](https://github.com/ryan-wong-coder/trustdb/actions/workflows/ci.yml/badge.svg)
 
-[中文说明](README.zh-CN.md) | [Contributing](CONTRIBUTING.md) | [`.sproof` format](formats/SPROOF_V1.md)
+[Official Website](https://ryan-wong-coder.github.io/trustdb-website/) | [中文说明](README.zh-CN.md) | [Contributing](CONTRIBUTING.md) | [`.sproof` format](formats/SPROOF_V1.md)
 
 TrustDB is a verifiable evidence database for file claims and proof exchange. It turns a local file hash into a signed claim, a durable server receipt, a batch Merkle proof, a global transparency-log proof, and optionally an externally anchored Signed Tree Head (STH).
+
+Documentation, quick start guides, releases, and feedback channels are available on the [TrustDB official website](https://ryan-wong-coder.github.io/trustdb-website/).
 
 ![TrustDB system architecture](assets/readme/system-architecture.png)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,9 +2,11 @@
 
 ![CI](https://github.com/ryan-wong-coder/trustdb/actions/workflows/ci.yml/badge.svg)
 
-[English README](README.md) | [贡献指南](CONTRIBUTING.md) | [`.sproof` 格式](formats/SPROOF_V1.md)
+[官方网站](https://ryan-wong-coder.github.io/trustdb-website/) | [English README](README.md) | [贡献指南](CONTRIBUTING.md) | [`.sproof` 格式](formats/SPROOF_V1.md)
 
 TrustDB 是一个面向文件存证和证明交换的可验证证据数据库。它把本地文件哈希转换为客户端签名声明、服务端持久化收据、批次 Merkle 证明、Global Transparency Log 证明，以及可选的外部 Signed Tree Head（STH）锚定结果。
+
+文档、快速开始、版本发布和反馈渠道统一维护在 [TrustDB 官方网站](https://ryan-wong-coder.github.io/trustdb-website/)。
 
 ![TrustDB 系统架构](assets/readme/system-architecture.png)
 


### PR DESCRIPTION
## Summary

- add the official TrustDB website to the English and Chinese README navigation
- point readers to the website for documentation, quick start guides, releases, and feedback
- set the GitHub repository homepage metadata for both `trustdb` and `trustdb-website`

## Validation

- official website returns HTTP 200
- `git diff --check`
