### PR TITLE
fix: constrain filesystem access

### DIFF
--- a/clients/desktop/app.go
+++ b/clients/desktop/app.go
@@ -27,14 +27,19 @@ import (
 // method here becomes a TypeScript-callable RPC. We collect them on
 // one struct so state (store, ctx) is shared without globals.
 type App struct {
-	ctx      context.Context
-	storeMu  sync.Mutex
-	store    *store
-	hashJobs *hashJobManager
+	ctx        context.Context
+	storeMu    sync.Mutex
+	store      *store
+	hashJobs   *hashJobManager
+	savePathMu sync.Mutex
+	savePaths  map[string]string
 }
 
 func NewApp() *App {
-	return &App{hashJobs: newHashJobManager()}
+	return &App{
+		hashJobs:  newHashJobManager(),
+		savePaths: make(map[string]string),
+	}
 }
 
 // Version returns a short string the UI puts in the footer so users
@@ -69,12 +74,54 @@ func (a *App) shutdown(ctx context.Context) {
 	a.store = nil
 }
 
-func (a *App) configDir() (string, error) {
+func (a *App) prepareConfigDir() (string, error) {
 	base, err := os.UserConfigDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(base, "TrustDB-Desktop"), nil
+	root, err := openUserConfigRoot(base)
+	if err != nil {
+		return "", err
+	}
+	defer root.Close()
+	const appDir = "TrustDB-Desktop"
+	if err := root.MkdirAll(appDir, 0o755); err != nil {
+		return "", err
+	}
+	appRoot, err := root.OpenRoot(appDir)
+	if err != nil {
+		return "", err
+	}
+	defer appRoot.Close()
+	return appRoot.Name(), nil
+}
+
+func openUserConfigRoot(base string) (*os.Root, error) {
+	root, err := os.OpenRoot(base)
+	if err == nil || !os.IsNotExist(err) {
+		return root, err
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	homeRoot, err := os.OpenRoot(home)
+	if err != nil {
+		return nil, err
+	}
+	defer homeRoot.Close()
+	rel, err := filepath.Rel(home, base)
+	if err != nil {
+		return nil, err
+	}
+	rel, err = cleanRootRelativePath(rel)
+	if err != nil {
+		return nil, fmt.Errorf("user config directory is outside the user home: %w", err)
+	}
+	if err := homeRoot.MkdirAll(rel, 0o755); err != nil {
+		return nil, err
+	}
+	return homeRoot.OpenRoot(rel)
 }
 
 func (a *App) ensureStore() error {
@@ -83,12 +130,9 @@ func (a *App) ensureStore() error {
 	if a.store != nil {
 		return nil
 	}
-	dir, err := a.configDir()
+	dir, err := a.prepareConfigDir()
 	if err != nil {
 		return fmt.Errorf("resolve config dir: %w", err)
-	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("create config dir: %w", err)
 	}
 	s, err := newStore(filepath.Join(dir, "config.json"))
 	if err != nil {
@@ -474,10 +518,14 @@ func (a *App) ChooseSavePath(title, defaultFile string) (string, error) {
 	if a.ctx == nil {
 		return "", errors.New("runtime not ready")
 	}
-	return wailsruntime.SaveFileDialog(a.ctx, wailsruntime.SaveDialogOptions{
+	selected, err := wailsruntime.SaveFileDialog(a.ctx, wailsruntime.SaveDialogOptions{
 		Title:           title,
 		DefaultFilename: defaultFile,
 	})
+	if err != nil || strings.TrimSpace(selected) == "" {
+		return selected, err
+	}
+	return a.rememberSavePath(selected)
 }
 
 func (a *App) ChooseOpenPath(title string) (string, error) {

--- a/clients/desktop/frontend/src/components/Onboarding.vue
+++ b/clients/desktop/frontend/src/components/Onboarding.vue
@@ -129,9 +129,10 @@ const registerCmd = computed(() => {
 })
 
 function shellQuote(s: string): string {
-  // Keep things readable for the 99% case but still correct for the
-  // occasional user who types a space into their tenant name.
-  return /^[A-Za-z0-9._/\-]+$/.test(s) ? s : `"${s.replace(/"/g, '\\"')}"`
+  // POSIX single quotes make backslashes, substitutions, and newlines
+  // literal. Embedded single quotes are represented by ending the quote,
+  // emitting one quoted single quote, and starting it again.
+  return /^[A-Za-z0-9._/\-]+$/.test(s) ? s : `'${s.replaceAll("'", `'"'"'`)}'`
 }
 
 async function copyCmd() {

--- a/clients/desktop/io.go
+++ b/clients/desktop/io.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/ryan-wong-coder/trustdb/internal/cborx"
 )
@@ -21,19 +25,36 @@ func marshalCBOR(v any) ([]byte, error) {
 // so an interrupted export never leaves a half-written file the
 // user might mistake for a valid proof.
 func writeFileAtomic(path string, data []byte, mode fs.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".*.tmp")
+	abs, err := filepath.Abs(strings.TrimSpace(path))
 	if err != nil {
 		return err
 	}
-	tmpPath := tmp.Name()
+	root, err := os.OpenRoot(filepath.Dir(abs))
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	return writeFileAtomicRoot(root, filepath.Base(abs), data, mode)
+}
+
+func writeFileAtomicRoot(root *os.Root, name string, data []byte, mode fs.FileMode) error {
+	name, err := cleanRootRelativePath(name)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(name)
+	if err := root.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, tmpName, err := createTempFileRoot(root, dir, filepath.Base(name))
+	if err != nil {
+		return err
+	}
 	cleanup := true
 	defer func() {
 		_ = tmp.Close()
 		if cleanup {
-			_ = os.Remove(tmpPath)
+			_ = root.Remove(tmpName)
 		}
 	}()
 	if _, err := tmp.Write(data); err != nil {
@@ -45,21 +66,39 @@ func writeFileAtomic(path string, data []byte, mode fs.FileMode) error {
 	if err := tmp.Close(); err != nil {
 		return err
 	}
-	if err := renameReplace(tmpPath, path); err != nil {
+	if err := renameReplaceRoot(root, tmpName, name); err != nil {
 		return err
 	}
 	cleanup = false
 	return nil
 }
 
-func renameReplace(src, dst string) error {
-	if err := rejectDirectoryTarget(dst); err != nil {
+func createTempFileRoot(root *os.Root, dir, base string) (*os.File, string, error) {
+	for range 128 {
+		var suffix [12]byte
+		if _, err := rand.Read(suffix[:]); err != nil {
+			return nil, "", err
+		}
+		name := filepath.Join(dir, "."+base+"."+hex.EncodeToString(suffix[:])+".tmp")
+		f, err := root.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+		if err == nil {
+			return f, name, nil
+		}
+		if !os.IsExist(err) {
+			return nil, "", err
+		}
+	}
+	return nil, "", errors.New("could not allocate temporary file")
+}
+
+func renameReplaceRoot(root *os.Root, src, dst string) error {
+	if err := rejectDirectoryTargetRoot(root, dst); err != nil {
 		return err
 	}
-	if err := os.Rename(src, dst); err != nil {
+	if err := root.Rename(src, dst); err != nil {
 		if os.IsExist(err) {
-			if removeErr := os.Remove(dst); removeErr == nil {
-				return os.Rename(src, dst)
+			if removeErr := root.Remove(dst); removeErr == nil {
+				return root.Rename(src, dst)
 			}
 		}
 		return err
@@ -67,11 +106,11 @@ func renameReplace(src, dst string) error {
 	return nil
 }
 
-func rejectDirectoryTarget(path string) error {
-	info, err := os.Stat(path)
+func rejectDirectoryTargetRoot(root *os.Root, name string) error {
+	info, err := root.Stat(name)
 	if err == nil {
 		if info.IsDir() {
-			return fmt.Errorf("%s is a directory", path)
+			return fmt.Errorf("%s is a directory", name)
 		}
 		return nil
 	}
@@ -79,4 +118,51 @@ func rejectDirectoryTarget(path string) error {
 		return nil
 	}
 	return err
+}
+
+func cleanRootRelativePath(name string) (string, error) {
+	clean := filepath.Clean(strings.TrimSpace(name))
+	if clean == "." || clean == ".." || filepath.IsAbs(clean) || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", errors.New("path must stay within the selected directory")
+	}
+	return clean, nil
+}
+
+func (a *App) rememberSavePath(path string) (string, error) {
+	abs, err := filepath.Abs(strings.TrimSpace(path))
+	if err != nil {
+		return "", err
+	}
+	abs = filepath.Clean(abs)
+	a.savePathMu.Lock()
+	defer a.savePathMu.Unlock()
+	if len(a.savePaths) >= 64 {
+		clear(a.savePaths)
+	}
+	a.savePaths[abs] = abs
+	return abs, nil
+}
+
+func (a *App) consumeSavePath(path string) (string, error) {
+	abs, err := filepath.Abs(strings.TrimSpace(path))
+	if err != nil {
+		return "", err
+	}
+	abs = filepath.Clean(abs)
+	a.savePathMu.Lock()
+	defer a.savePathMu.Unlock()
+	authorized, ok := a.savePaths[abs]
+	if !ok {
+		return "", errors.New("output path was not selected with the native save dialog")
+	}
+	delete(a.savePaths, abs)
+	return authorized, nil
+}
+
+func (a *App) writeAuthorizedFile(path string, data []byte, mode fs.FileMode) error {
+	authorized, err := a.consumeSavePath(path)
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(authorized, data, mode)
 }

--- a/clients/desktop/store.go
+++ b/clients/desktop/store.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -144,12 +145,12 @@ type recordEvent struct {
 // store serialises config and record mutations through a mutex. Config
 // remains a tiny JSON file; records use a Pebble-backed local index.
 type store struct {
-	mu            sync.Mutex
-	path          string
-	recordsPath   string
-	recordsDBPath string
-	data          configFile
-	records       *localRecordDB
+	mu          sync.Mutex
+	root        *os.Root
+	configName  string
+	recordsName string
+	data        configFile
+	records     *localRecordDB
 }
 
 func defaultSettings() Settings {
@@ -163,20 +164,35 @@ func defaultSettings() Settings {
 }
 
 func newStore(path string) (*store, error) {
-	recordsDBPath := path + ".records.pebble"
-	records, err := openLocalRecordDB(recordsDBPath)
+	abs, err := filepath.Abs(path)
 	if err != nil {
 		return nil, err
 	}
+	root, err := os.OpenRoot(filepath.Dir(abs))
+	if err != nil {
+		return nil, err
+	}
+	configName, err := cleanRootRelativePath(filepath.Base(abs))
+	if err != nil {
+		_ = root.Close()
+		return nil, err
+	}
+	recordsDBPath := filepath.Join(root.Name(), configName+".records.pebble")
+	records, err := openLocalRecordDB(recordsDBPath)
+	if err != nil {
+		_ = root.Close()
+		return nil, err
+	}
 	s := &store{
-		path:          path,
-		recordsPath:   path + ".records.jsonl",
-		recordsDBPath: recordsDBPath,
-		data:          configFile{Settings: defaultSettings()},
-		records:       records,
+		root:        root,
+		configName:  configName,
+		recordsName: configName + ".records.jsonl",
+		data:        configFile{Settings: defaultSettings()},
+		records:     records,
 	}
 	if err := s.load(); err != nil {
 		_ = records.close()
+		_ = root.Close()
 		return nil, err
 	}
 	return s, nil
@@ -186,7 +202,7 @@ func (s *store) load() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	loaded := configFile{Settings: defaultSettings()}
-	raw, err := os.ReadFile(s.path)
+	raw, err := s.root.ReadFile(s.configName)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return err
@@ -227,11 +243,11 @@ func (s *store) quarantineCorruptLocked(raw []byte) {
 	if len(raw) == 0 {
 		return
 	}
-	backup := fmt.Sprintf("%s.bad-%s", s.path, time.Now().UTC().Format("20060102T150405.000000000Z"))
-	if err := os.Rename(s.path, backup); err == nil {
+	backup := fmt.Sprintf("%s.bad-%s", s.configName, time.Now().UTC().Format("20060102T150405.000000000Z"))
+	if err := s.root.Rename(s.configName, backup); err == nil {
 		return
 	}
-	_ = os.WriteFile(backup, raw, 0o600)
+	_ = s.root.WriteFile(backup, raw, 0o600)
 }
 
 func (s *store) persistLocked() error {
@@ -241,13 +257,13 @@ func (s *store) persistLocked() error {
 	if err != nil {
 		return err
 	}
-	return writeFileAtomic(s.path, raw, 0o600)
+	return writeFileAtomicRoot(s.root, s.configName, raw, 0o600)
 }
 
 func (s *store) close() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.records.close()
+	return errors.Join(s.records.close(), s.root.Close())
 }
 
 func (s *store) snapshot() configFile {
@@ -385,7 +401,7 @@ func (s *store) migrateLegacyRecordsLocked(configRecords []LocalRecord) error {
 }
 
 func (s *store) loadLegacyRecordLogLocked(records map[string]LocalRecord) error {
-	f, err := os.Open(s.recordsPath)
+	f, err := s.root.Open(s.recordsName)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil

--- a/clients/desktop/store_test.go
+++ b/clients/desktop/store_test.go
@@ -27,6 +27,20 @@ func TestStoreLoadMissingConfigUsesDefaults(t *testing.T) {
 	}
 }
 
+func TestOpenUserConfigRootCreatesMissingDirectoryUnderHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	base := filepath.Join(home, ".config", "trustdb-test")
+	root, err := openUserConfigRoot(base)
+	if err != nil {
+		t.Fatalf("openUserConfigRoot() error = %v", err)
+	}
+	defer root.Close()
+	if root.Name() != base {
+		t.Fatalf("root.Name() = %q, want %q", root.Name(), base)
+	}
+}
+
 func TestWriteFileAtomicIgnoresStaleFixedTempPath(t *testing.T) {
 	t.Parallel()
 
@@ -89,6 +103,50 @@ func TestWriteFileAtomicRejectsDirectoryTarget(t *testing.T) {
 	}
 }
 
+func TestWriteFileAtomicRejectsSymlinkOutsideParent(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.tdproof")
+	if err := os.WriteFile(outside, []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, "proof.tdproof")
+	if err := os.Symlink(outside, target); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := writeFileAtomic(target, []byte("replaced"), 0o644); err == nil {
+		t.Fatal("writeFileAtomic() error = nil, want symlink escape error")
+	}
+	got, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "original" {
+		t.Fatalf("outside file = %q, want original", got)
+	}
+}
+
+func TestWriteAuthorizedFileRequiresNativeSelection(t *testing.T) {
+	t.Parallel()
+
+	app := NewApp()
+	path := filepath.Join(t.TempDir(), "proof.tdproof")
+	if err := app.writeAuthorizedFile(path, []byte("proof"), 0o644); err == nil {
+		t.Fatal("writeAuthorizedFile() accepted an unselected path")
+	}
+	authorized, err := app.rememberSavePath(path)
+	if err != nil {
+		t.Fatalf("rememberSavePath() error = %v", err)
+	}
+	if err := app.writeAuthorizedFile(authorized, []byte("proof"), 0o644); err != nil {
+		t.Fatalf("writeAuthorizedFile() error = %v", err)
+	}
+	if err := app.writeAuthorizedFile(authorized, []byte("again"), 0o644); err == nil {
+		t.Fatal("writeAuthorizedFile() reused a consumed path authorization")
+	}
+}
+
 func TestStorePersistIgnoresStaleFixedTempPath(t *testing.T) {
 	t.Parallel()
 
@@ -121,6 +179,25 @@ func TestStorePersistIgnoresStaleFixedTempPath(t *testing.T) {
 	}
 	if !staleInfo.IsDir() {
 		t.Fatalf("stale fixed temp path was modified; isDir=false")
+	}
+}
+
+func TestStoreRejectsConfigSymlinkOutsideRoot(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(outside, []byte(`{"settings":{"server_url":"http://outside.invalid"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "config.json")
+	if err := os.Symlink(outside, path); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	store, err := newStore(path)
+	if err == nil {
+		_ = store.close()
+		t.Fatal("newStore() followed a config symlink outside its root")
 	}
 }
 

--- a/clients/desktop/submit.go
+++ b/clients/desktop/submit.go
@@ -252,7 +252,7 @@ func (a *App) ExportProofBundle(recordID, outPath string) error {
 	if err != nil {
 		return err
 	}
-	return writeFileAtomic(outPath, raw, 0o644)
+	return a.writeAuthorizedFile(outPath, raw, 0o644)
 }
 
 // ExportGlobalProof writes the batch->STH inclusion proof needed for L4/L5
@@ -278,7 +278,7 @@ func (a *App) ExportGlobalProof(recordID, outPath string) error {
 	if err != nil {
 		return err
 	}
-	return writeFileAtomic(outPath, raw, 0o644)
+	return a.writeAuthorizedFile(outPath, raw, 0o644)
 }
 
 // ExportSingleProof writes the recommended .sproof artefact: one CBOR file
@@ -296,7 +296,7 @@ func (a *App) ExportSingleProof(recordID, outPath string) error {
 	if err != nil {
 		return err
 	}
-	return writeFileAtomic(outPath, raw, 0o644)
+	return a.writeAuthorizedFile(outPath, raw, 0o644)
 }
 
 func (a *App) buildSingleProof(recordID string) (model.SingleProof, error) {
@@ -417,7 +417,7 @@ func (a *App) ExportAnchorResult(recordID, outPath string) error {
 	if err != nil {
 		return err
 	}
-	return writeFileAtomic(outPath, raw, 0o644)
+	return a.writeAuthorizedFile(outPath, raw, 0o644)
 }
 
 // GetProofBundle exposes the latest server-side bundle to the UI

--- a/internal/adminweb/adminweb_test.go
+++ b/internal/adminweb/adminweb_test.go
@@ -355,3 +355,32 @@ func TestSPAFileServerRejectsSiblingPrefixTraversal(t *testing.T) {
 		t.Fatalf("served file outside web root: %q", rec.Body.String())
 	}
 }
+
+func TestSPAFileServerRejectsSymlinkOutsideRoot(t *testing.T) {
+	t.Parallel()
+	parent := t.TempDir()
+	root := filepath.Join(parent, "web")
+	outside := filepath.Join(parent, "outside-secret.txt")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "index.html"), []byte("<!doctype html><title>admin</title>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(outside, []byte("outside-secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "leak.txt")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/leak.txt", nil)
+	rec := httptest.NewRecorder()
+	spaFileServer(root).ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d body=%q, want 404", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "outside-secret") {
+		t.Fatalf("served symlink target outside web root: %q", rec.Body.String())
+	}
+}

--- a/internal/adminweb/handler.go
+++ b/internal/adminweb/handler.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -409,34 +410,58 @@ func (h spaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	clean := filepath.Clean(strings.TrimPrefix(r.URL.Path, "/"))
-	if clean == "." {
-		clean = ""
-	}
-	full := filepath.Join(h.root, filepath.FromSlash(clean))
-	if !pathWithinRoot(h.root, full) {
+	name, ok := spaRelativePath(r.URL.Path)
+	if !ok {
 		http.NotFound(w, r)
 		return
 	}
-	if st, err := os.Stat(full); err == nil && !st.IsDir() {
-		http.ServeFile(w, r, full)
+	root, err := os.OpenRoot(h.root)
+	if err != nil {
+		http.NotFound(w, r)
 		return
 	}
-	http.ServeFile(w, r, filepath.Join(h.root, "index.html"))
+	defer root.Close()
+	if name != "" {
+		served, exists := serveRootFile(w, r, root, name)
+		if served {
+			return
+		}
+		if exists {
+			http.NotFound(w, r)
+			return
+		}
+	}
+	if served, _ := serveRootFile(w, r, root, "index.html"); served {
+		return
+	}
+	http.NotFound(w, r)
 }
 
-func pathWithinRoot(root, path string) bool {
-	rootAbs, err := filepath.Abs(root)
-	if err != nil {
-		return false
+func spaRelativePath(urlPath string) (string, bool) {
+	if strings.Contains(urlPath, `\`) {
+		return "", false
 	}
-	pathAbs, err := filepath.Abs(path)
-	if err != nil {
-		return false
+	clean := path.Clean(strings.TrimPrefix(urlPath, "/"))
+	if clean == "." {
+		return "", true
 	}
-	rel, err := filepath.Rel(rootAbs, pathAbs)
-	if err != nil {
-		return false
+	if clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", false
 	}
-	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel)
+	return filepath.FromSlash(clean), true
+}
+
+func serveRootFile(w http.ResponseWriter, r *http.Request, root *os.Root, name string) (served, exists bool) {
+	f, err := root.Open(name)
+	if err != nil {
+		_, statErr := root.Lstat(name)
+		return false, statErr == nil
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil || st.IsDir() {
+		return false, true
+	}
+	http.ServeContent(w, r, filepath.Base(name), st.ModTime(), f)
+	return true, true
 }

--- a/internal/proofstore/local.go
+++ b/internal/proofstore/local.go
@@ -113,27 +113,43 @@ func (s LocalStore) ListRecordIndexes(ctx context.Context, opts model.RecordList
 		return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list record indexes canceled", err)
 	}
 	limit := normaliseRecordLimit(opts.Limit)
-	dir := s.recordByTimeDir()
+	dir := filepath.Join("records", "by-time")
 	switch {
 	case len(opts.ContentHash) > 0:
-		dir = s.recordByContentDir(opts.ContentHash)
+		dir = filepath.Join("records", "by-content", hex.EncodeToString(opts.ContentHash))
 	case model.RecordStorageQueryToken(opts.Query) != "":
-		dir = s.recordByStorageTokenDir(model.RecordStorageQueryToken(opts.Query))
+		dir = filepath.Join("records", "by-storage-token", recordTokenPart(model.RecordStorageQueryToken(opts.Query)))
 	case opts.BatchID != "":
-		dir = s.recordByBatchDir(opts.BatchID)
+		dir = filepath.Join("records", "by-batch", safeFileName(opts.BatchID))
 	case opts.ProofLevel != "":
-		dir = s.recordByProofLevelDir(opts.ProofLevel)
+		dir = filepath.Join("records", "by-proof-level", safeFileName(opts.ProofLevel))
 	case opts.TenantID != "":
-		dir = s.recordByTenantDir(opts.TenantID)
+		dir = filepath.Join("records", "by-tenant", safeFileName(opts.TenantID))
 	case opts.ClientID != "":
-		dir = s.recordByClientDir(opts.ClientID)
+		dir = filepath.Join("records", "by-client", safeFileName(opts.ClientID))
 	}
-	entries, err := os.ReadDir(dir)
+	root, err := os.OpenRoot(s.root())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "open proofstore root", err)
+	}
+	defer root.Close()
+	dirFile, err := root.Open(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
 		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "read record index directory", err)
+	}
+	entries, err := dirFile.ReadDir(-1)
+	closeErr := dirFile.Close()
+	if err != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "read record index directory", err)
+	}
+	if closeErr != nil {
+		return nil, trusterr.Wrap(trusterr.CodeDataLoss, "close record index directory", closeErr)
 	}
 	indexes := make([]model.RecordIndex, 0, len(entries))
 	for _, entry := range entries {
@@ -143,7 +159,7 @@ func (s LocalStore) ListRecordIndexes(ctx context.Context, opts model.RecordList
 		if err := ctx.Err(); err != nil {
 			return nil, trusterr.Wrap(trusterr.CodeDeadlineExceeded, "proofstore list record indexes canceled", err)
 		}
-		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		data, err := root.ReadFile(filepath.Join(dir, entry.Name()))
 		if err != nil {
 			return nil, trusterr.Wrap(trusterr.CodeDataLoss, "read record index", err)
 		}

--- a/internal/proofstore/local_test.go
+++ b/internal/proofstore/local_test.go
@@ -113,6 +113,37 @@ func TestLocalStoreBundleReadsLegacyEscapedPath(t *testing.T) {
 	}
 }
 
+func TestLocalStoreListRecordIndexesRejectsSymlinkOutsideRoot(t *testing.T) {
+	t.Parallel()
+
+	store := LocalStore{Root: t.TempDir()}
+	outside := t.TempDir()
+	idx := model.RecordIndex{
+		SchemaVersion:   model.SchemaRecordIndex,
+		RecordID:        "outside-record",
+		TenantID:        "tenant-a",
+		ReceivedAtUnixN: 1,
+	}
+	if err := writeCBORAtomic(filepath.Join(outside, "outside.tdrecord"), idx); err != nil {
+		t.Fatalf("write outside record: %v", err)
+	}
+	linkDir := filepath.Join(store.Root, "records", "by-tenant", "tenant-a")
+	if err := os.MkdirAll(filepath.Dir(linkDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, linkDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	indexes, err := store.ListRecordIndexes(context.Background(), model.RecordListOptions{TenantID: "tenant-a"})
+	if err == nil {
+		t.Fatalf("ListRecordIndexes() indexes=%+v error=nil, want symlink escape error", indexes)
+	}
+	if len(indexes) != 0 {
+		t.Fatalf("ListRecordIndexes() returned outside indexes: %+v", indexes)
+	}
+}
+
 func TestSafeFileNameAvoidsLegacyCollisions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- serve Admin SPA assets through `os.Root` so traversal and symlink escapes cannot leave `admin.web_dir`
- read LocalStore indexes through a root-scoped filesystem and reject external symlink directories
- move desktop config, legacy migration, and atomic writes to root-scoped filesystem operations
- require a one-time native Save dialog authorization before desktop proof exports can write a path
- replace incomplete double-quote escaping with POSIX single-quote shell encoding

## Security impact

This addresses the 17 high-severity findings from the first CodeQL default-setup scan:

- 16 `go/path-injection` findings
- 1 `js/incomplete-sanitization` finding

The new regression tests cover SPA symlink escape, LocalStore symlink escape, desktop config symlink escape, arbitrary export paths, one-time save authorization, and atomic-write symlink targets.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./...`
- `go test -tags=e2e ./cmd/trustdb`
- `go test -race ./...` in `clients/desktop`
- `npm run build` in `clients/web`
- `npm run build` in `clients/desktop/frontend`
- `git diff --check`
