### PR TITLE
Fix proof level parsing and clarify comments

### DIFF
--- a/clients/desktop/submit.go
+++ b/clients/desktop/submit.go
@@ -281,7 +281,7 @@ func (a *App) ExportGlobalProof(recordID, outPath string) error {
 	return a.writeAuthorizedFile(outPath, raw, 0o644)
 }
 
-// ExportSingleProof writes the recommended .sproof artefact: one CBOR file
+// ExportSingleProof writes the recommended .sproof artifact: one CBOR file
 // containing the L1-L3 ProofBundle plus any currently available L4 GlobalLog
 // proof and L5 STH anchor result.
 func (a *App) ExportSingleProof(recordID, outPath string) error {
@@ -387,7 +387,7 @@ func (a *App) UpgradeOtsAnchor(recordID string) (*anchor.OtsUpgradeSummary, erro
 	return &summary, nil
 }
 
-// ExportAnchorResult mirrors ExportProofBundle for L5 artefacts.
+// ExportAnchorResult mirrors ExportProofBundle for L5 artifacts.
 // Emitting a separate file keeps each level independently verifiable
 // (you can hand out the ProofBundle without the anchor).
 func (a *App) ExportAnchorResult(recordID, outPath string) error {

--- a/internal/merkle/merkle.go
+++ b/internal/merkle/merkle.go
@@ -201,8 +201,9 @@ func (t Tree) Proofs() [][][]byte {
 	return out
 }
 
-// ProofView returns an immutable audit path backed by the tree's compact hash
-// storage. Callers must not mutate the returned byte slices.
+// ProofView returns a read-only audit path view backed by the tree's compact
+// hash storage. Callers must not mutate the returned byte slices; use Proof
+// when mutable copies are required.
 func (t Tree) ProofView(index int) ([][]byte, error) {
 	if index < 0 || index >= len(t.leafHashes) {
 		return nil, fmt.Errorf("merkle: leaf index out of range: %d", index)

--- a/internal/prooflevel/prooflevel.go
+++ b/internal/prooflevel/prooflevel.go
@@ -5,6 +5,8 @@
 // reachable without inventing intermediate trust.
 package prooflevel
 
+import "strings"
+
 type Level string
 
 const (
@@ -88,9 +90,10 @@ func Definitions() []Definition {
 }
 
 func Parse(raw string) (Level, bool) {
-	switch Level(raw) {
+	level := Level(strings.ToUpper(strings.TrimSpace(raw)))
+	switch level {
 	case L1, L2, L3, L4, L5:
-		return Level(raw), true
+		return level, true
 	default:
 		return Unknown, false
 	}

--- a/internal/prooflevel/prooflevel_test.go
+++ b/internal/prooflevel/prooflevel_test.go
@@ -1,6 +1,9 @@
 package prooflevel
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestEvaluate(t *testing.T) {
 	t.Parallel()
@@ -177,10 +180,11 @@ func TestDefinitionsReturnsCopy(t *testing.T) {
 func TestParse(t *testing.T) {
 	t.Parallel()
 
-	for _, raw := range []string{"L1", "L2", "L3", "L4", "L5"} {
+	for _, raw := range []string{"L1", "L2", "L3", "L4", "L5", " l5 "} {
 		got, ok := Parse(raw)
-		if !ok || got.String() != raw {
-			t.Fatalf("Parse(%q) = %q, %v", raw, got, ok)
+		want := strings.ToUpper(strings.TrimSpace(raw))
+		if !ok || got.String() != want {
+			t.Fatalf("Parse(%q) = %q, %v, want %q true", raw, got, ok, want)
 		}
 	}
 	if got, ok := Parse("L6"); ok || got != Unknown {


### PR DESCRIPTION
## What changed

- Normalize proof-level input by trimming whitespace and accepting case-insensitive `L1`–`L5` values.
- Extend parsing tests to cover normalized input while preserving rejection of unknown levels.
- Correct `artifact` spelling in desktop export comments.
- Clarify that `ProofView` is a read-only view backed by tree storage, and direct callers to `Proof` when mutable copies are needed.

## Why

`Parse` previously required an exact uppercase value, so otherwise valid user input with surrounding whitespace or lowercase characters was rejected. A Merkle API comment also described backed storage as immutable, which overstated the guarantee.

## Impact

Proof-level parsing is more tolerant at input boundaries, test coverage now protects that behavior, and API/export comments more accurately describe the implementation.

## Validation

- `go test ./internal/prooflevel ./internal/merkle`
